### PR TITLE
Another approach to API

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
         </dd>
         <dt>Promise request()</dt>
         <dd>
-          Calling this method causes the underlying platform to keep the screen in active state, preventing it from dimming or locking until user unlocks it.
+          Calling this method should ask the underlying OS for acquiring the lock of specified type. Returned <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a> must be resolved when lock is actually acquired or acquiring failed. It may fail due to security reasons or bacause requested lock type is not supported by UA or by OS.
           <dl class="parameters">
             <dt>WakeLockType type</dt>
             <dd>Type of wake lock resource to request</dd>
@@ -114,7 +114,7 @@
         </dd>
         <dt>Promise release()</dt>
         <dd>
-          Calling this method releases the wake lock. The screen will no longer be kept awake and it could switch off again.
+          Calling this method must release the previously acquired wake lock. If wake lock of given type is not actually held, it has no effect. Method returns <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a>, which is released with success when the wake lock is actually released (immediately if lock isn't held). It may resolve with failure if underlying OS failed to release wake lock for some reason.
           <dl class="parameters">
             <dt>WakeLockType type</dt>
             <dd>Type of wake lock resource to release</dd>

--- a/index.html
+++ b/index.html
@@ -95,10 +95,34 @@
     <section id="WakeLock">
       <h2><code>WakeLock interface</code></h2>
       <dl class="idl" title="interface WakeLock">
-        <dt>readonly attribute boolean isHeld</dt>
-        <dd>Contains value telling if WakeLock object is still keeping the screen awake. It equals <code>true</code> if wake lock is still active, otherwise it is <code>false</code>.</dd>
+        <dt>attribute EventHandler? onstatuschange</dt>
+        <dd>An event handler for <code>wakelockstatuschange</code> event.</dd>
+        <dt>readonly attribute WakeLockStatus status</dt>
+        <dd>Contains current status of the WakeLock object.</dd>
         <dt>void release()</dt>
-        <dd>Calling this method releases the WakeLock object. If no other active locks exist, the screen will no longer be kept awake and it could dim or lock afterwards. Calling this method is not required because WakeLock objects are automatically released when they go out of scope.</dd>
+        <dd>Calling this method releases the WakeLock object. If no other active locks exist, the screen will no longer be kept awake and it could switch off again.</dd>
+      </dl>
+    </section>
+    <section id="wakelockstatuschange">
+      <h2><code>wakelockstatuschange</code> Event</h2>
+      <p>
+        This event is used to notify about WakeLock object status changes. If the wake lock was lost for any reason - it was released explicitly or that was caused by current browsing context activity state change - this event must be fired.
+      </p>
+      <p>
+        User agents must deliver these events by <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#queue-a-task">
+        queuing a task</a> to <a class="external" href="http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#concept-event-fire">
+        fire an event</a> of the appropriate name with its <code>status</code> attribute set to the new status of WakeLock object.
+      </p> 
+    </section>
+    <section id="WakeLockStatus">
+      <h2><code>WakeLockStatus enumeration</code></h2>
+      <dl class="idl" title="enum WakeLockStatus">
+        <dt>unknown</dt>
+        <dd>Status of the WakeLock object is undefined.</dd>
+        <dt>locked</dt>
+        <dd>This WakeLock object keeps lock and prevents screen from being turned off.</dd>
+        <dt>unlocked</dt>
+        <dd>This WakeLock object was released for some reason.</dd>
       </dl>
     </section>
     <section id="security">
@@ -124,6 +148,33 @@ function ongamestarted() {
             screen.requestWakeLock().then(function(lock) {
             game.wakeLock = lock;
         });
+    }
+}
+
+function ongamefinished() {
+    // release previously acquired lock
+    if (game.wakeLock) {
+        game.wakeLock.release();
+    }
+}
+      </pre>
+      <p>Observing a wake lock status with event handler</p>
+      <pre class="example highlight">
+var game = {};
+
+function ongamestarted() {
+    // check if requestWakeLock supported and then lock the screen
+    if (screen.requestWakeLock) {
+        screen.requestWakeLock().then(function(lock) {
+            game.wakeLock = lock;
+            game.wakeLock.onstatuschange = onwakelockchanged;
+        });
+    }
+}
+
+function onwakelockchanged(status) {
+    if (status === "unlocked") {
+        console.log('Wake lock was lost.');
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -121,10 +121,10 @@ var game = {};
 function ongamestarted() {
     // check if requestWakeLock supported and then lock the screen
     if (screen.requestWakeLock) {
-        screen.requestWakeLock().then(function(lock) {
-        game.wakeLock = lock;
-    });
-  }
+            screen.requestWakeLock().then(function(lock) {
+            game.wakeLock = lock;
+        });
+    }
 }
 
 function ongamefinished() {

--- a/index.html
+++ b/index.html
@@ -77,61 +77,49 @@
     <section>
       <h2>Terminology</h2>
       <p>
-        The <code><a href="http://www.w3.org/TR/cssom-view/#the-screen-interface">Screen</a></code> interface
-        this specification extends is defined in [[!cssom-view]].
+        The concept <a href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a> is defined in [[!HTML5]].
       </p>
       <p>
         The <code><a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">Promise</a></code> interface
         this specification uses is defined in [[!ECMASCRIPT]].
       </p>
     </section>
-    <section id="screen.wakelock">
-      <h2><code>Screen interface extensions</code></h2>
-      <dl class="idl" title="partial interface Screen">
+    <section id="navigator.wakelock">
+      <h2><code>Navigator interface extensions</code></h2>
+      <dl class="idl" title="partial interface Navigator">
         <dt>readonly attribute WakeLock wakeLock</dt>
         <dd>An object of type <code>WakeLock</code>, responsible for acquiring and releasing the screen wake lock. It is a global object, tied to current browsing context.</dd>
       </dl>
     </section>
     <section id="WakeLock">
       <h2><code>WakeLock interface</code></h2>
-      <p>Objects of this type cannot be constructed, they only exist as a property of some global object like <code>Screen</code>. In future we may add an ability to lock cpu, wifi or some other resource. For that purposes there may be introduced new properties like <code>system.cpu.wakeLock</code>, <code>network.wifi.wakeLock</code>, etc.</p> 
+      <p>Objects of this type cannot be constructed, only one instance of it exists as a property of <code>Navigator</code>.
       <dl class="idl" title="interface WakeLock">
-        <dt>attribute EventHandler? onstatuschange</dt>
-        <dd>An event handler for <code>wakelockstatuschange</code> event.</dd>
-        <dt>readonly attribute WakeLockStatus status</dt>
-        <dd>Contains current status of the WakeLock object.</dd>
-        <dt>Promise acquire()</dt>
+        <dt>Promise request()</dt>
         <dd>
           Calling this method causes the underlying platform to keep the screen in active state, preventing it from dimming or locking until user unlocks it.
           <dl class="parameters">
-            <dt>optional unsigned int timeout</dt>
-            <dd>Sets the maximum time for wake lock to be active, in milliseconds. Lock will be released automatically after this time. Zero value is equals to infinite timeout.</dd>
+            <dt>WakeLockType type</dt>
+            <dd>Type of wake lock resource to request</dd>
           </dl>
         </dd>
         <dt>Promise release()</dt>
-        <dd>Calling this method releases the wake lock. The screen will no longer be kept awake and it could switch off again.</dd>
+        <dd>
+          Calling this method releases the wake lock. The screen will no longer be kept awake and it could switch off again.
+          <dl class="parameters">
+            <dt>WakeLockType type</dt>
+            <dd>Type of wake lock resource to release</dd>
+          </dl>
+        </dd>
       </dl>
     </section>
-    <section id="wakelockstatuschange">
-      <h2><code>wakelockstatuschange</code> Event</h2>
-      <p>
-        This event is used to notify about WakeLock object status changes. If the wake lock was lost for any reason - it was released explicitly or that was caused by current browsing context activity state change - this event must be fired.
-      </p>
-      <p>
-        User agents must deliver these events by <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#queue-a-task">
-        queuing a task</a> to <a class="external" href="http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#concept-event-fire">
-        fire an event</a> of the appropriate name with its <code>status</code> attribute set to the new status of WakeLock object.
-      </p> 
-    </section>
-    <section id="WakeLockStatus">
-      <h2><code>WakeLockStatus enumeration</code></h2>
-      <dl class="idl" title="enum WakeLockStatus">
-        <dt>unknown</dt>
-        <dd>Status of the WakeLock object is undefined.</dd>
-        <dt>locked</dt>
-        <dd>This WakeLock object is currently locked.</dd>
-        <dt>unlocked</dt>
-        <dd>This WakeLock object was released for some reason.</dd>
+    <section id="WakeLockType">
+      <h2><code>WakeLockType enumeration</code></h2>
+      <dl class="idl" title="enum WakeLockType">
+        <dt>screen</dt>
+        <dd>This wake lock is intended to keep awake device screen.</dd>
+        <dt>system</dt>
+        <dd>This wake lock is intended to keep awake device cpu, radio and other system services, except the screen.</dd>
       </dl>
     </section>
     <section id="security">
@@ -140,79 +128,24 @@
       <p>Keeping the screen from dimming or locking can drain the underlying device power reserve. Preventing it from locking may expose the device and its content to unwanted parties if the user expected it to lock automatically.</p>
       <p>To mitigate the risks mentioned above, user agents may want to:</p>
       <ul>
-        <li>Only resolve resulting Promise of <code>screen.wakeLock.acquire</code> on visible browsing contexts;</li>
-        <li>Do not resolve resulting Promise of <code>screen.wakeLock.acquire</code> when the power reserve reaches low levels;</li>
+        <li>Only resolve resulting Promise of <code>navigator.wakeLock.request</code> on visible browsing contexts;</li>
+        <li>Do not resolve resulting Promise of <code>navigator.wakeLock.request</code> when the power reserve reaches low levels;</li>
         <li>Alert the user when the first request to lock screen happens, with the option of banning further use of that feature from the given origin;</li>
         <li>Highlight in some way browsing contexts, keeping the screen lock to inform user about it.</li>
     </section>
 
     <section id="examples">
       <h2>Examples</h2>
-      <p>Acquiring and releasing screen wake lock</p>
       <pre class="example highlight">
-function ongamestarted() {
-    // check if screen wake locks supported and then lock the screen until we manually release it.
-    if (screen.wakeLock) {
-        screen.wakeLock.acquire().then(function() {
-            // ...
-        });
-    }
-}
+//lock display when the recipe is showing: 
+$( "#recipe" ).on( "show", function() {
+    navigator.wakeLock.request("display").then(haveFun, boo) 
+} ); 
 
-function ongamefinished() {
-    // release previously acquired lock
-    if (screen.wakeLock) {
-        screen.wakeLock.release().then(function() {
-            // ...
-        });
-    }
-}
-      </pre>
-      <p>Observing a wake lock status with event handler</p>
-      <pre class="example highlight">
-function ongamestarted() {
-    // check if screen wake locks supported and then lock the screen
-    if (screen.wakeLock) {
-        screen.wakeLock.acquire().then(function() {
-            // lock acquired, now start receiving events about its status changes
-            screen.wakeLock.onstatuschange = onwakelockchanged;
-        });
-    }
-}
-
-function onwakelockchanged(status) {
-    if (status === "unlocked") {
-        console.log('Wake lock was lost.');
-    } else if (status === "locked") {
-        console.log('Wake lock was acquired.');
-    }
-}
-
-function ongamefinished() {
-    // release previously acquired lock
-    if (screen.wakeLock) {
-        screen.wakeLock.release();
-    }
-}
-      </pre>
-      <p>Acquiring a wake lock for limited time</p>
-      <pre class="example highlight">
-// For comfortable reading we need to keep backlight on for some reasonable time, like 2 minutes
-function onopenbook() {
-    if (screen.wakeLock) {
-        // acquire screen lock for time given from application settings
-        screen.wakeLock.acquire(app.settings.backlightTimeout).then(function() {
-            // ...
-        });
-    }
-}
-
-function onclosebook() {
-    // release previously acquired lock
-    if (screen.wakeLock) {
-        screen.wakeLock.release();
-    }
-}
+//release lock: 
+$( "#recipe" ).on( "hide", function() {
+    navigator.wakeLock.release("display") 
+} ); 
       </pre>
     </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -173,5 +173,11 @@ navigator.wakeLock.onlockchanged = function(locktype) {
 }
       </pre>
     </section>
+
+    <section class="appendix informative" id="acknowledgments">
+      <h2>Acknowledgments</h2>
+      <p>I would like to offer my sincere thanks to Mounir Lamouri, Sergei Konstantinov and Matvei Larionov for their contributions to this work.</p>
+    </section>
+
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -90,14 +90,14 @@
       <p>User agents must deliver this event by <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#queue-a-task">queuing a task</a> to <a href="http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#concept-event-fire">fire an event</a> of the appropriate name with its <code>WakeLockType</code> attribute set to type of lock being acquired or released.</p>
     </section>
     <section id="navigator.wakelock">
-      <h2><code>Navigator interface extensions</code></h2>
+      <h2><code>Navigator</code> interface extensions</h2>
       <dl class="idl" title="partial interface Navigator">
         <dt>readonly attribute WakeLock wakeLock</dt>
         <dd>An object of type <code>WakeLock</code>, responsible for acquiring and releasing the screen wake lock. It is a global object, tied to current browsing context.</dd>
       </dl>
     </section>
     <section id="WakeLock">
-      <h2><code>WakeLock interface</code></h2>
+      <h2><code>WakeLock</code> interface</h2>
       <p>Objects of this type cannot be constructed, only one instance of it exists as a property of <code>Navigator</code>.
       <dl class="idl" title="interface WakeLock">
         <dt>attribute EventHandler? onlockchanged</dt>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
       };
     </script>
   </head>
+  
   <body>
     <section id='abstract'>
       <p>

--- a/index.html
+++ b/index.html
@@ -126,9 +126,9 @@
       <h2><code>WakeLockType enumeration</code></h2>
       <dl class="idl" title="enum WakeLockType">
         <dt>screen</dt>
-        <dd>This wake lock is intended to keep awake device screen.</dd>
+        <dd>This wake lock is intended to keep awake device screen preventing if from switching off and going to sleep.</dd>
         <dt>system</dt>
-        <dd>This wake lock is intended to keep awake device cpu, radio and other system services, except the screen.</dd>
+        <dd>This wake lock is intended to keep awake device cpu, radio and other system services. Screen may dim or switch off.</dd>
       </dl>
     </section>
     <section id="security">

--- a/index.html
+++ b/index.html
@@ -81,8 +81,8 @@
         this specification extends is defined in [[!cssom-view]].
       </p>
       <p>
-        The <code><a href="http://www.w3.org/TR/2013/WD-dom-20131107/#promises">Promise</a></code> interface
-        this specification uses is defined in [[!DOM4]].
+        The <code><a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">Promise</a></code> interface
+        this specification uses is defined in [[!ECMASCRIPT]].
       </p>
     </section>
     <section id="screen.wakelock">

--- a/index.html
+++ b/index.html
@@ -139,12 +139,12 @@
       <pre class="example highlight">
 //lock display when the recipe is showing: 
 $( "#recipe" ).on( "show", function() {
-    navigator.wakeLock.request("display").then(haveFun, boo) 
+    navigator.wakeLock.request("screen").then(haveFun, boo) 
 } ); 
 
 //release lock: 
 $( "#recipe" ).on( "hide", function() {
-    navigator.wakeLock.release("display") 
+    navigator.wakeLock.release("screen") 
 } ); 
       </pre>
     </section>

--- a/index.html
+++ b/index.html
@@ -85,22 +85,31 @@
         this specification uses is defined in [[!DOM4]].
       </p>
     </section>
-    <section id="screen.requestWakeLock">
+    <section id="screen.wakelock">
       <h2><code>Screen interface extensions</code></h2>
       <dl class="idl" title="partial interface Screen">
-        <dt>Promise requestWakeLock()</dt>
-        <dd>Calling this method causes the underlying platform to keep the screen in active state, preventing it from dimming or locking until user unlocks it.</dd>
+        <dt>readonly attribute WakeLock lock</dt>
+        <dd>An object of type <code>WakeLock</code>, responsible for acquiring and releasing the screen wake lock. It is a global object, tied to current browsing context.</dd>
       </dl>
     </section>
     <section id="WakeLock">
       <h2><code>WakeLock interface</code></h2>
+      <p>Objects of this type cannot be constructed, they only exist as a property of some global object like <code>Screen</code>. In future we may add an ability to lock cpu, wifi or some other resource. For that purposes there may be introduced new properties like <code>system.cpu.lock</code>, <code>network.wifi.lock</code>, etc.</p> 
       <dl class="idl" title="interface WakeLock">
         <dt>attribute EventHandler? onstatuschange</dt>
         <dd>An event handler for <code>wakelockstatuschange</code> event.</dd>
         <dt>readonly attribute WakeLockStatus status</dt>
         <dd>Contains current status of the WakeLock object.</dd>
-        <dt>void release()</dt>
-        <dd>Calling this method releases the WakeLock object. If no other active locks exist, the screen will no longer be kept awake and it could switch off again.</dd>
+        <dt>Promise acquire()</dt>
+        <dd>
+          Calling this method causes the underlying platform to keep the screen in active state, preventing it from dimming or locking until user unlocks it.
+          <dl class="parameters">
+            <dt>optional unsigned int timeout</dt>
+            <dd>Sets the maximum time for wake lock to be active, in milliseconds. Lock will be released automatically after this time. Zero value is equals to infinite timeout.</dd>
+          </dl>
+        </dd>
+        <dt>Promise release()</dt>
+        <dd>Calling this method releases the wake lock. The screen will no longer be kept awake and it could switch off again.</dd>
       </dl>
     </section>
     <section id="wakelockstatuschange">
@@ -120,7 +129,7 @@
         <dt>unknown</dt>
         <dd>Status of the WakeLock object is undefined.</dd>
         <dt>locked</dt>
-        <dd>This WakeLock object keeps lock and prevents screen from being turned off.</dd>
+        <dd>This WakeLock object is currently locked.</dd>
         <dt>unlocked</dt>
         <dd>This WakeLock object was released for some reason.</dd>
       </dl>
@@ -131,43 +140,42 @@
       <p>Keeping the screen from dimming or locking can drain the underlying device power reserve. Preventing it from locking may expose the device and its content to unwanted parties if the user expected it to lock automatically.</p>
       <p>To mitigate the risks mentioned above, user agents may want to:</p>
       <ul>
-        <li>Only resolve resulting Promise of <code>screen.requestWakeLock</code> on visible browsing contexts;</li>
-        <li>Do not resolve resulting Promise of <code>screen.requestWakeLock</code> when the power reserve reaches low levels;</li>
+        <li>Only resolve resulting Promise of <code>screen.lock.acquire</code> on visible browsing contexts;</li>
+        <li>Do not resolve resulting Promise of <code>screen.lock.acquire</code> when the power reserve reaches low levels;</li>
         <li>Alert the user when the first request to lock screen happens, with the option of banning further use of that feature from the given origin;</li>
         <li>Highlight in some way browsing contexts, keeping the screen lock to inform user about it.</li>
     </section>
 
     <section id="examples">
       <h2>Examples</h2>
+      <p>Acquiring and releasing screen wake lock</p>
       <pre class="example highlight">
-var game = {};
-
 function ongamestarted() {
-    // check if requestWakeLock supported and then lock the screen
-    if (screen.requestWakeLock) {
-            screen.requestWakeLock().then(function(lock) {
-            game.wakeLock = lock;
+    // check if screen wake locks supported and then lock the screen until we manually release it.
+    if (screen.lock) {
+        screen.lock.acquire().then(function() {
+            // ...
         });
     }
 }
 
 function ongamefinished() {
     // release previously acquired lock
-    if (game.wakeLock) {
-        game.wakeLock.release();
+    if (screen.lock) {
+        screen.lock.release().then(function() {
+            // ...
+        });
     }
 }
       </pre>
       <p>Observing a wake lock status with event handler</p>
       <pre class="example highlight">
-var game = {};
-
 function ongamestarted() {
-    // check if requestWakeLock supported and then lock the screen
-    if (screen.requestWakeLock) {
-        screen.requestWakeLock().then(function(lock) {
-            game.wakeLock = lock;
-            game.wakeLock.onstatuschange = onwakelockchanged;
+    // check if screen wake locks supported and then lock the screen
+    if (screen.lock) {
+        screen.lock.acquire().then(function() {
+            // lock acquired, now start receiving events about its status changes
+            screen.lock.onstatuschange = onwakelockchanged;
         });
     }
 }
@@ -175,13 +183,15 @@ function ongamestarted() {
 function onwakelockchanged(status) {
     if (status === "unlocked") {
         console.log('Wake lock was lost.');
+    } else if (status === "locked") {
+        console.log('Wake lock was acquired.');
     }
 }
 
 function ongamefinished() {
     // release previously acquired lock
-    if (game.wakeLock) {
-        game.wakeLock.release();
+    if (screen.lock) {
+        screen.lock.release();
     }
 }
       </pre>

--- a/index.html
+++ b/index.html
@@ -120,6 +120,14 @@
             <dd>Type of wake lock resource to release</dd>
           </dl>
         </dd>
+        <dt>boolean isHeld()</dt>
+        <dd>
+          Calling this method must return actual status for wake lock of given type: is it currently acquired or not. If wake lock type is not supported by UA or by underlying OS, the method should return false.
+          <dl class="parameters">
+            <dt>WakeLockType type</dt>
+            <dd>Type of wake lock which status we'd like to determine</dd>
+          </dl>
+        </dd>
       </dl>
     </section>
     <section id="WakeLockType">

--- a/index.html
+++ b/index.html
@@ -88,13 +88,13 @@
     <section id="screen.wakelock">
       <h2><code>Screen interface extensions</code></h2>
       <dl class="idl" title="partial interface Screen">
-        <dt>readonly attribute WakeLock lock</dt>
+        <dt>readonly attribute WakeLock wakeLock</dt>
         <dd>An object of type <code>WakeLock</code>, responsible for acquiring and releasing the screen wake lock. It is a global object, tied to current browsing context.</dd>
       </dl>
     </section>
     <section id="WakeLock">
       <h2><code>WakeLock interface</code></h2>
-      <p>Objects of this type cannot be constructed, they only exist as a property of some global object like <code>Screen</code>. In future we may add an ability to lock cpu, wifi or some other resource. For that purposes there may be introduced new properties like <code>system.cpu.lock</code>, <code>network.wifi.lock</code>, etc.</p> 
+      <p>Objects of this type cannot be constructed, they only exist as a property of some global object like <code>Screen</code>. In future we may add an ability to lock cpu, wifi or some other resource. For that purposes there may be introduced new properties like <code>system.cpu.wakeLock</code>, <code>network.wifi.wakeLock</code>, etc.</p> 
       <dl class="idl" title="interface WakeLock">
         <dt>attribute EventHandler? onstatuschange</dt>
         <dd>An event handler for <code>wakelockstatuschange</code> event.</dd>
@@ -140,8 +140,8 @@
       <p>Keeping the screen from dimming or locking can drain the underlying device power reserve. Preventing it from locking may expose the device and its content to unwanted parties if the user expected it to lock automatically.</p>
       <p>To mitigate the risks mentioned above, user agents may want to:</p>
       <ul>
-        <li>Only resolve resulting Promise of <code>screen.lock.acquire</code> on visible browsing contexts;</li>
-        <li>Do not resolve resulting Promise of <code>screen.lock.acquire</code> when the power reserve reaches low levels;</li>
+        <li>Only resolve resulting Promise of <code>screen.wakeLock.acquire</code> on visible browsing contexts;</li>
+        <li>Do not resolve resulting Promise of <code>screen.wakeLock.acquire</code> when the power reserve reaches low levels;</li>
         <li>Alert the user when the first request to lock screen happens, with the option of banning further use of that feature from the given origin;</li>
         <li>Highlight in some way browsing contexts, keeping the screen lock to inform user about it.</li>
     </section>
@@ -152,8 +152,8 @@
       <pre class="example highlight">
 function ongamestarted() {
     // check if screen wake locks supported and then lock the screen until we manually release it.
-    if (screen.lock) {
-        screen.lock.acquire().then(function() {
+    if (screen.wakeLock) {
+        screen.wakeLock.acquire().then(function() {
             // ...
         });
     }
@@ -161,8 +161,8 @@ function ongamestarted() {
 
 function ongamefinished() {
     // release previously acquired lock
-    if (screen.lock) {
-        screen.lock.release().then(function() {
+    if (screen.wakeLock) {
+        screen.wakeLock.release().then(function() {
             // ...
         });
     }
@@ -172,10 +172,10 @@ function ongamefinished() {
       <pre class="example highlight">
 function ongamestarted() {
     // check if screen wake locks supported and then lock the screen
-    if (screen.lock) {
-        screen.lock.acquire().then(function() {
+    if (screen.wakeLock) {
+        screen.wakeLock.acquire().then(function() {
             // lock acquired, now start receiving events about its status changes
-            screen.lock.onstatuschange = onwakelockchanged;
+            screen.wakeLock.onstatuschange = onwakelockchanged;
         });
     }
 }
@@ -190,8 +190,8 @@ function onwakelockchanged(status) {
 
 function ongamefinished() {
     // release previously acquired lock
-    if (screen.lock) {
-        screen.lock.release();
+    if (screen.wakeLock) {
+        screen.wakeLock.release();
     }
 }
       </pre>
@@ -199,9 +199,9 @@ function ongamefinished() {
       <pre class="example highlight">
 // For comfortable reading we need to keep backlight on for some reasonable time, like 2 minutes
 function onopenbook() {
-    if (screen.lock) {
+    if (screen.wakeLock) {
         // acquire screen lock for time given from application settings
-        screen.lock.acquire(app.settings.backlightTimeout).then(function() {
+        screen.wakeLock.acquire(app.settings.backlightTimeout).then(function() {
             // ...
         });
     }
@@ -209,8 +209,8 @@ function onopenbook() {
 
 function onclosebook() {
     // release previously acquired lock
-    if (screen.lock) {
-        screen.lock.release();
+    if (screen.wakeLock) {
+        screen.wakeLock.release();
     }
 }
       </pre>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
       };
     </script>
   </head>
-  
   <body>
     <section id='abstract'>
       <p>

--- a/index.html
+++ b/index.html
@@ -84,6 +84,11 @@
         this specification uses is defined in [[!ECMASCRIPT]].
       </p>
     </section>
+    <section id="wakelockchanged">
+      <h2><code>wakelockchanged</code> event</h2>
+      <p>This event is used to communicate wake lock state change or an error in changing state. It is named <b>wakelockchanged</b>. If wake lock is acquired or released for any reason a <a href="#wakelockchanged" class="internalDFN">wakelockchanged</a> event must be sent.</p>
+      <p>User agents must deliver this event by <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#queue-a-task">queuing a task</a> to <a href="http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#concept-event-fire">fire an event</a> of the appropriate name with its <code>WakeLockType</code> attribute set to type of lock being acquired or released.</p>
+    </section>
     <section id="navigator.wakelock">
       <h2><code>Navigator interface extensions</code></h2>
       <dl class="idl" title="partial interface Navigator">
@@ -95,6 +100,10 @@
       <h2><code>WakeLock interface</code></h2>
       <p>Objects of this type cannot be constructed, only one instance of it exists as a property of <code>Navigator</code>.
       <dl class="idl" title="interface WakeLock">
+        <dt>attribute EventHandler? onlockchanged</dt>
+        <dd>
+          An <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#event-handlers">event handler</a> for <a href="#wakelockchanged" class="internalDFN">wakelockchanged</a> events.
+        </dd>
         <dt>Promise request()</dt>
         <dd>
           Calling this method causes the underlying platform to keep the screen in active state, preventing it from dimming or locking until user unlocks it.
@@ -146,6 +155,14 @@ $( "#recipe" ).on( "show", function() {
 $( "#recipe" ).on( "hide", function() {
     navigator.wakeLock.release("screen") 
 } ); 
+      </pre>
+      <p>Example of using wakelockchanged events</p>
+      <pre class="example highlight">
+navigator.wakeLock.onlockchanged = function(locktype) {
+    if (locktype === "screen") {
+        console.log("Oops, screen wake lock was lost.");
+    }
+}
       </pre>
     </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -195,6 +195,25 @@ function ongamefinished() {
     }
 }
       </pre>
+      <p>Acquiring a wake lock for limited time</p>
+      <pre class="example highlight">
+// For comfortable reading we need to keep backlight on for some reasonable time, like 2 minutes
+function onopenbook() {
+    if (screen.lock) {
+        // acquire screen lock for time given from application settings
+        screen.lock.acquire(app.settings.backlightTimeout).then(function() {
+            // ...
+        });
+    }
+}
+
+function onclosebook() {
+    // release previously acquired lock
+    if (screen.lock) {
+        screen.lock.release();
+    }
+}
+      </pre>
     </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -116,25 +116,22 @@
     <section id="examples">
       <h2>Examples</h2>
       <pre class="example highlight">
-var lock = {};
+var game = {};
 
-// check if requestWakeLock supported and then lock the screen
-if (window.screen.requestWakeLock) {
-  window.screen.requestWakeLock().then(function(l) {
-    lock = l;
-  });
+function ongamestarted() {
+    // check if requestWakeLock supported and then lock the screen
+    if (screen.requestWakeLock) {
+        screen.requestWakeLock().then(function(lock) {
+        game.wakeLock = lock;
+    });
+  }
 }
 
-// only do work if lock is actually held
-if (lock.isHeld) {
-    // do some work
-}
-
-// not necessary to release the lock,
-// it will be automatically released after destruction.
-// However, you can still release it manually when you don't need it anymore.
-if (lock) {
-  lock.release();
+function ongamefinished() {
+    // release previously acquired lock
+    if (game.wakeLock) {
+        game.wakeLock.release();
+    }
 }
       </pre>
     </section>


### PR DESCRIPTION
So, I decided to abandon the idea with multiple WakeLock objects, as there was much negative feedback about it.
Now we consider WakeLock object as a singleton, with acquire/release methods. Each WakeLock would be associated with one type of resource - screen, cpu, wifi, etc., so that you have to acquire `screen.wakeLock`, `system.cpu.wakeLock`, etc. for corresponding resource. Developer can safely acquire it many times and release it only once (or wait for page to unload, or maybe wait for page to exit fullscreen). If he needs reference counting - he should implement it himself. No GC bindings at all :)
