### PR TITLE
chore(.travis): use node lts (#115)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
       - g++-4.8
 before_install:
   - export CXX="g++-4.8" CC="gcc-4.8"
-  - nvm install 6
+  - nvm install --lts
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
ReSpec doesn't support Node 6 anymore. It's follows Node LTS.