### PR TITLE
Add implementationReportURI

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
         wgPublicList: "public-device-apis",
         wgPatentURI: "https://www.w3.org/2004/01/pp-impl/43696/status",
         testSuiteURI: "https://w3c-test.org/wake-lock/",
+        implementationReportURI: "https://www.w3.org/2009/dap/wiki/ImplementationStatus",
         otherLinks: [{
             key: 'Quality Assurance Lead',
             data: [{


### PR DESCRIPTION
CR, PR, and REC documents need to have an `implementationReportURI` defined as kindly reported by ReSpec in the [staged CR snapshot][1].

See also: [CfC: CR of Wake Lock API, review by 6 Dec][2]

[1]: https://w3c.github.io/wake-lock/?specStatus=CR;previousMaturity=WD;previousPublishDate=2017-11-21;crEnd=2018-01-18;publishDate=2017-12-07

[2]: https://lists.w3.org/Archives/Public/public-device-apis/2017Nov/0007.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/wake-lock/implementation-report-link.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/wake-lock/63ce17f...a4200b5.html)