### PR TITLE
Fix formatting in WakeLock.request()'s description

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,7 +594,7 @@
                   run <a>abort the request steps</a>.
                   </li>
                   <li data-link-for="">If |lock|'s |type| is {{
-                  WakeLockType["screen"] }} and the {{Document} of the
+                  WakeLockType["screen"] }} and the {{Document}} of the
                   <a>top-level browsing context</a> is <a>hidden</a>, reject
                   |promise| with a "{{NotAllowedError}}" {{DOMException}}, and
                   run <a>abort the request steps</a>.


### PR DESCRIPTION
Properly close a `{{Document}}` reference.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/188.html" title="Last updated on Apr 25, 2019, 1:47 PM UTC (9954602)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/188/d5c5b24...rakuco:9954602.html" title="Last updated on Apr 25, 2019, 1:47 PM UTC (9954602)">Diff</a>