### PR TITLE
examples: Do not make tryKeepScreenAlive() async

### DIFF
--- a/index.html
+++ b/index.html
@@ -944,7 +944,7 @@
         Examples
       </h2>
       <pre class="example js" title="Acquire and releases a screen wake lock">
-        async function tryKeepScreenAlive(minutes) {
+        function tryKeepScreenAlive(minutes) {
           const lock = new WakeLock("screen");
           lock.request();
 


### PR DESCRIPTION
Ever since Wake Lock became constructible in #155 the example no longer uses
await, so there is no reason to keep the function itself async.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/189.html" title="Last updated on Apr 25, 2019, 2:11 PM UTC (144082d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/189/b24c13e...rakuco:144082d.html" title="Last updated on Apr 25, 2019, 2:11 PM UTC (144082d)">Diff</a>