### PR TITLE
Stop referencing "feature name" from the Feature Policy spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,9 +164,8 @@
       </h3>
       <p data-tests=
       "wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html, wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html, wakelock-enabled-by-feature-policy-attribute.https.sub.html, wakelock-enabled-by-feature-policy.https.sub.html">
-        The <dfn>wake lock feature</dfn> is a <a>policy-controlled feature</a>
-        with <a data-cite="feature-policy#feature-name">feature name</a>
-        `"wake-lock"` and <a>default allowlist</a> `["self"]`.
+        The Wake Lock API defines a <a>policy-controlled feature</a> identified
+        by the string `"wake-lock"`. Its <a>default allowlist</a> is `["self"]`.
       </p>
       <div class="note">
         <p>


### PR DESCRIPTION
Our ReSpec checks have been failing because the concept has not existed in
the Feature Policy spec since early 2018 due to
https://github.com/w3c/webappsec-feature-policy/pull/131.

Follow the suggestions from that pull request on how to define a
policy-controlled feature in a spec to fix things.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/190.html" title="Last updated on Apr 25, 2019, 2:50 PM UTC (5308c84)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/190/aa7a585...rakuco:5308c84.html" title="Last updated on Apr 25, 2019, 2:50 PM UTC (5308c84)">Diff</a>