### PR TITLE
Remove the "outstanding wake lock request" definition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,8 +379,7 @@
             </td>
             <td>
               The value indicates the amount of current requests for the
-              <a>wake lock type</a>. A number greater than zero indicates an
-              <dfn>outstanding wake lock request</dfn>
+              <a>wake lock type</a>.
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
It used to be relevant before #150, which rewrote a lot of prose and
algorithms and stopped referencing it anywhere in the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/191.html" title="Last updated on Apr 26, 2019, 4:28 PM UTC (28db2ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/191/9279abd...rakuco:28db2ed.html" title="Last updated on Apr 26, 2019, 4:28 PM UTC (28db2ed)">Diff</a>