### PR TITLE
Do not assign a default value to WakeLockRequestOptions.signal

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,7 +547,7 @@
       <section data-dfn-for="WakeLockRequestOptions"> <h3>The <dfn>WakeLockRequestOptions</dfn> dictionary</h3>
         <pre class="idl">
           dictionary WakeLockRequestOptions {
-            AbortSignal? signal = null;
+            AbortSignal? signal;
           };
         </pre>
         <p>


### PR DESCRIPTION
In Web IDL, the following `WakeLockRequestOptions` instances in JavaScript
should have the same effect (a dictionary that does _not_ have the `signal`
member present):

    {}
    {signal: undefined}

which are different from

    {signal: null}

which means a `WakeLockRequestOptions` dictionary with one member, `signal`,
whose value is `null`.

Setting a default value to the nullable member `signal` means we'd always
have a `signal` member in the dictionary even when we do not set it at
all (first 2 cases), which is not needed and does not make sense.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/203.html" title="Last updated on May 3, 2019, 4:55 PM UTC (08cc160)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/203/f569790...rakuco:08cc160.html" title="Last updated on May 3, 2019, 4:55 PM UTC (08cc160)">Diff</a>