### PR TITLE
Make WakeLockRequestOptions' signal non-nullable, do not set a default

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,7 +431,7 @@
       <section data-dfn-for="WakeLockRequestOptions"> <h3>The <dfn>WakeLockRequestOptions</dfn> dictionary</h3>
         <pre class="idl">
           dictionary WakeLockRequestOptions {
-            AbortSignal? signal = null;
+            AbortSignal signal;
           };
         </pre>
         <p>
@@ -498,16 +498,16 @@
               </li>
             </ol>
           </li>
-          <li data-link-for="WakeLockRequestOptions">Let |signal:AbortSignal| be
-          |options|'s {{signal}} member if present, or `null`.
+          <li data-link-for="WakeLockRequestOptions">If |options|' {{signal}}
+          member is present, then run the following steps:
             <ol>
-              <li>If |signal| is not `null` and |signal|’s <a
-              data-cite="dom">aborted flag</a> is set, then reject |promise|
-              with an "{{AbortError}}" {{DOMException}} and return |promise|.
+              <li>Let |signal:AbortSignal| be |options|'s {{signal}} member.
               </li>
-              <li>If |signal| is not `null` and |signal|'s <a
-              data-cite="dom">aborted flag</a> is not set, [=AbortSignal/add=]
-              to |signal|:
+              <li>If |signal|’s <a data-cite="dom">aborted flag</a> is set,
+              then reject |promise| with an "{{AbortError}}" {{DOMException}}
+              and return |promise|.
+              </li>
+              <li>Otherwise, [=AbortSignal/add=] to |signal|:
                 <ol>
                   <li>Run <a>release a wake lock</a> with |promise| and |type|.
                   </li>
@@ -515,15 +515,16 @@
               </li>
             </ol>
           </li>
-          <li>Run the following steps <a>in parallel</a>, but <a>abort when</a>
-          |signal| is not `null` and |signal|'s <a data-cite="dom">aborted
-          flag</a> is set:
+          <li data-link-for="WakeLockRequestOptions">Run the following steps
+          <a>in parallel</a>, but <a>abort when</a> |options|' {{signal}}
+          member is present and its <a data-cite="dom">aborted flag</a> is set:
             <ol>
               <li>Let |state:PermissionState| be the result of awaiting <a>
               obtain permission</a> steps with |type|:
                 <ol>
                   <li>If |state| is {{"denied"}}, then reject |promise| with a
-                  "{{NotAllowedError}}" {{DOMException}}, and abort these steps.
+                  "{{NotAllowedError}}" {{DOMException}}, and abort these
+                  steps.
                   </li>
                 </ol>
               </li>
@@ -531,7 +532,8 @@
                 <a>acquire a wake lock</a> with |promise| and |type|:
                 <ol>
                   <li>If |success| is `false` then reject |promise| with a
-                  "{{NotAllowedError}}" {{DOMException}}, and abort these steps.
+                  "{{NotAllowedError}}" {{DOMException}}, and abort these
+                  steps.
                   </li>
                 </ol>
               </li>


### PR DESCRIPTION
In Web IDL, the following `WakeLockRequestOptions` instances in JavaScript
should have the same effect (a dictionary that does _not_ have the `signal`
member present):

    {}
    {signal: undefined}

which are different from

    {signal: null}

which means a `WakeLockRequestOptions` dictionary with one member, `signal`,
whose value is `null`.

Setting a default value to the nullable member `signal` means we'd always
have a `signal` member in the dictionary even when we do not set it at
all (first 2 cases), which is not needed and does not make sense.

Additionally, `signal` does not need to be nullable to begin with: by
default, dictionary members do not need to be present, so just make it a
regular, non-nullable member that can either not be present or be set to an
AbortSignal, but not null.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/204.html" title="Last updated on May 23, 2019, 11:30 AM UTC (fc328c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/204/ad4afbd...rakuco:fc328c3.html" title="Last updated on May 23, 2019, 11:30 AM UTC (fc328c3)">Diff</a>