### PR TITLE
chore(.travis): use GET instead of HEAD for ReSpec validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
  - npm install respec-validator
 script:
  - make check
- - npx respec-validator --gh-user=$GH_USER --gh-token=$GH_TOKEN index.html
+ - npx respec-validator --gh-user=$GH_USER --gh-token=$GH_TOKEN --check-links-using-get index.html
 env:
   global:
     - URL="http://w3c.github.io/wake-lock/W3CTRMANIFEST"


### PR DESCRIPTION
cc @rakuco

Work around chromestatus not allowing HEAD requests. 