### PR TITLE
Fix AbortSignal handling in WakeLock.request() after #201

### DIFF
--- a/index.html
+++ b/index.html
@@ -498,16 +498,27 @@
               </li>
             </ol>
           </li>
-          <li>Return |promise| and run the following steps <a>in parallel</a>:
+          <li data-link-for="WakeLockRequestOptions">Let |signal:AbortSignal| be
+          |options|'s {{signal}} member if present, or `null`.
             <ol>
-              <li data-link-for="WakeLockRequestOptions">
-              Let |signal:AbortSignal| be |options|'s {{signal}} member if
-              present, or `null`.
+              <li>If |signal| is not `null` and |signal|’s <a
+              data-cite="dom">aborted flag</a> is set, then reject |promise|
+              with an "{{AbortError}}" {{DOMException}} and return |promise|.
               </li>
-              <li>If |signal| is not `null` and |signal|’s <a>aborted flag</a>
-                is set, then reject |promise| with an "{{AbortError}}" {{DOMException}},
-                and abort these steps.
+              <li>If |signal| is not `null` and |signal|'s <a
+              data-cite="dom">aborted flag</a> is not set, [=AbortSignal/add=]
+              to |signal|:
+                <ol>
+                  <li>Run <a>release a wake lock</a> with |promise| and |type|.
+                  </li>
+                </ol>
               </li>
+            </ol>
+          </li>
+          <li>Run the following steps <a>in parallel</a>, but <a>abort when</a>
+          |signal| is not `null` and |signal|'s <a data-cite="dom">aborted
+          flag</a> is set:
+            <ol>
               <li>Let |state:PermissionState| be the result of awaiting <a>
               obtain permission</a> steps with |type|:
                 <ol>
@@ -515,10 +526,6 @@
                   "{{NotAllowedError}}" {{DOMException}}, and abort these steps.
                   </li>
                 </ol>
-              </li>
-              <li>If |signal| is not `null` and |signal|’s <a>aborted flag</a>
-                is set, then reject |promise| with an "{{AbortError}}" {{DOMException}},
-                and abort these steps.
               </li>
               <li>Let |success:boolean| be the result of awaiting
                 <a>acquire a wake lock</a> with |promise| and |type|:
@@ -528,21 +535,9 @@
                   </li>
                 </ol>
               </li>
-              <li>If |signal| is not `null`:
-                <ol>
-                  <li>If |signal|’s <a>aborted flag</a> is set, then reject |promise|
-                  with an "{{AbortError}}" {{DOMException}}, and abort these steps.
-                  </li>
-                  <li>
-                    [=AbortSignal/Add=] to |signal|:
-                    <ol>
-                      <li>Run <a>release a wake lock</a> with |promise| and |type|.
-                      </li>
-                    </ol>
-                  </li>
-                </ol>
-              </li>
             </ol>
+          </li>
+          <li>Return |promise|.
           </li>
         </ol>
       </section>


### PR DESCRIPTION
Address some of the review comments from that PR:
* The checks for `options.signal` were repeated multiple times across the
  algorithm in an attempt to cover what happens if `AbortController.abort()`
  is called during the parallel steps.
  Switch to using the Infra spec's "abort when" concept which does the exact
  same thing (i.e. "do this check between each step and abort the steps if
  the condition becomes true") while making the text easier to read.
* Handle `AbortSignal` before the parallel steps too: if the aborted flag is
  set, we do not even need to enter the parallel steps; if it is not set we
  can add "release wake lock" to the `AbortSignal` and that covers the "if
  aborted" concept from the Infra spec that goes together with the "abort
  when" concept mentioned above.

While here, also fix what "aborted flag" points to: rather than pointing to
the definition the DOM spec, it was pointing to a separate concept from the
Fetch spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/209.html" title="Last updated on May 23, 2019, 10:25 AM UTC (3d97752)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/209/c189496...rakuco:3d97752.html" title="Last updated on May 23, 2019, 10:25 AM UTC (3d97752)">Diff</a>