### PR TITLE
Fix the checkbox example after #201

### DIFF
--- a/index.html
+++ b/index.html
@@ -852,11 +852,11 @@
 
         let controller;
 
-        checkbox.onclick = () =&gt; {
+        checkbox.onclick = async () =&gt; {
           try {
             if (checkbox.checked) {
               controller = new AbortController();
-              WakeLock.request("screen", { signal: controller.signal });
+              await WakeLock.request("screen", { signal: controller.signal });
             } else if (controller) {
               controller.abort();
             }


### PR DESCRIPTION
The onclick handler needs to be an async function, and we need to use await
when calling WakeLock.request() for the try-catch block work as expected.

While here, also fix the example with two wake locks sharing the same
`AbortSignal`, as it was not specifying the keys for
`WakeLockRequestOptions` (broken since #194).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/210.html" title="Last updated on May 14, 2019, 3:39 PM UTC (7604dcc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/210/3ecd18f...rakuco:7604dcc.html" title="Last updated on May 14, 2019, 3:39 PM UTC (7604dcc)">Diff</a>