### PR TITLE
Make index.html pass tidy's checks after #201

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,18 +455,20 @@
           </li>
           <li>Let |document:Document| be the <a>responsible document</a> of the
           <a>current settings object</a>.
-          <ol>
-            </li>
-            <li data-tests="wakelock-disabled-by-feature-policy.https.sub.html">
-            If |document| is not <a>allowed to use</a> the <a>policy-controlled
-            feature</a> named "`wake-lock`", reject |promise| with a
-            "{{NotAllowedError}}" {{DOMException}} and return |promise|.
-            </li>
-            <li>If the <a>user agent</a> <a data-lt="deny wake lock">denies the
-            wake lock</a> of this |type| for |document|, reject |promise|
-            with a "{{NotAllowedError}}" {{DOMException}} and return |promise|.
-            </li>
-          </ol>
+            <ol>
+              <li data-tests="wakelock-disabled-by-feature-policy.https.sub.html">
+              If |document| is not <a>allowed to use</a> the
+              <a>policy-controlled feature</a> named "`wake-lock`", reject
+              |promise| with a "{{NotAllowedError}}" {{DOMException}} and
+              return |promise|.
+              </li>
+              <li>If the <a>user agent</a> <a data-lt="deny wake lock">denies
+              the wake lock</a> of this |type| for |document|, reject |promise|
+              with a "{{NotAllowedError}}" {{DOMException}} and return
+              |promise|.
+              </li>
+            </ol>
+          </li>
           <li>If the <a>current global object</a> is the
           {{DedicatedWorkerGlobalScope}} object:
             <ol>
@@ -722,17 +724,17 @@
           succeeded, or else `false`.
           </li>
           <li>If |active| is `true`:           
+            <ol>
+              <li>Let |document:Document| be the <a>responsible document</a> of
+              the <a>current settings object</a>.
+              </li>
+              <li>Let |record| be the <a>platform wake lock</a>'s <a>state
+              record</a> associated with |document| and |type|.
+              </li>
+              <li>Add |lockPromise| to |record|.{{[[ActiveLocks]]}}.
+              </li>
+            </ol>
           </li>
-          <ol>
-            <li>Let |document:Document| be the <a>responsible document</a> of the
-            <a>current settings object</a>.
-            </li>
-            <li>Let |record| be the <a>platform wake lock</a>'s <a>state
-            record</a> associated with |document| and |type|.
-            </li>
-            <li>Add |lockPromise| to |record|.{{[[ActiveLocks]]}}.
-            </li>
-          </ol>
           <li>Return |active|.
           </li>
         </ol>


### PR DESCRIPTION
Move a few tags around so that we can pass validation again. This gets rid
of the following errors:

    line 458 column 11 - Warning: missing </ol> before </li>
    line 443 column 7 - Warning: missing </section> before <li>
    line 470 column 11 - Warning: inserting implicit <ul>
    line 548 column 9 - Warning: discarding unexpected </ol>
    line 470 column 11 - Warning: missing </ul> before </section>
    line 726 column 11 - Warning: missing <li>
    line 724 column 11 - Info: missing optional end tag </li>
    line 458 column 11 - Warning: trimming empty <ol>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/211.html" title="Last updated on May 14, 2019, 3:08 PM UTC (cb76b8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/211/7088477...rakuco:cb76b8b.html" title="Last updated on May 14, 2019, 3:08 PM UTC (cb76b8b)">Diff</a>