### PR TITLE
Make page visibility checks use the resposible document.

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,11 +493,9 @@
               |promise| with a "{{NotAllowedError}}" {{DOMException}},
               and return |promise|.
               </li>
-              <li data-link-for="">If |type| is {{
-              WakeLockType["screen"] }} and the {{Document}} of the
-              <a>top-level browsing context</a> is <a>hidden</a>, reject
-              |promise| with a "{{NotAllowedError}}" {{DOMException}},
-              and return |promise|.
+              <li>If |type| is {{WakeLockType["screen"] }} and |document| is
+              <a>hidden</a>, reject |promise| with a "{{NotAllowedError}}"
+              {{DOMException}}, and return |promise|.
               </li>
             </ol>
           </li>
@@ -669,12 +667,12 @@
         </h3>
         <p>
           When the user agent determines that the <a>visibility state</a> of
-          the {{Document}} of the <a>top-level browsing context</a> changes, it
-          must run these steps:
+          the <a>responsible document</a> of the <a>current settings object</a>
+          changes, it must run these steps:
         </p>
         <ol class="algorithm">
-          <li>Let |document:Document| be the {{Document}} of the <a>top-level browsing
-          context</a>.
+          <li>Let |document:Document| be the <a>responsible document</a> of the
+          <a>current settings object</a>.
           </li>
           <li>If |document|'s <a>visibility state</a> is `"visible"`, abort
           these steps.
@@ -694,9 +692,9 @@
         </ol>
         <aside class="note">
           As some locks like {{ WakeLockType["system"] }} are allowed to run
-          while the {{Document}} of the <a>top-level browsing context</a> is
-          not visible, it is encouraged that user agents show some UI
-          indicating this.
+          while the <a>responsible document</a> of the <a>current settings
+          object</a> is not visible, it is encouraged that user agents show
+          some UI indicating this.
         </aside>
         <aside class="note">
           The <a>visibility state</a> is only exposed on the {{Window}} object,


### PR DESCRIPTION
Rather than using the top-level browsing context, apply the checks to the
responsible document of the current settings object. In practice, this helps
reduce complexity since we now always check the document where a wake lock
was created, rather than a possibly different top-level frame.

Fixes #206.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/212.html" title="Last updated on May 16, 2019, 8:48 AM UTC (f762308)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/212/f4de491...rakuco:f762308.html" title="Last updated on May 16, 2019, 8:48 AM UTC (f762308)">Diff</a>