### PR TITLE
Tweak reference to Page Lifecycle's "frozen" definition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,8 +121,8 @@
       </p>
       <p>
         Any active wake lock MUST also prevent the page from entering UA
-        induced <a data-cite="page-lifecycle#lifecycle-frozen">CPU
-        suspension</a> as defined by [[PAGE-LIFECYCLE]].
+        induced <a data-cite="page-lifecycle#frozen">CPU suspension</a> as
+        defined by [[PAGE-LIFECYCLE]].
       </p>
       <p>
         This specification defines the following <dfn>wake lock types</dfn>:


### PR DESCRIPTION
This adapts to wicg/page-lifecycle#32, which got rid of the
"lifecycle-frozen" definition in favor of another one called just "frozen".

This fixes our reference and makes spec validation pass again.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/213.html" title="Last updated on May 15, 2019, 4:13 PM UTC (c4f3587)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/213/3ecd18f...rakuco:c4f3587.html" title="Last updated on May 15, 2019, 4:13 PM UTC (c4f3587)">Diff</a>