### PR TITLE
Tweak a bit on the description of WakeLock interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,9 +393,8 @@
         The <dfn>WakeLock</dfn> interface
       </h2>
       <p>
-        The {{WakeLock}} interface allows the page to request wake locks of a
-        particular type, to determine the current wake lock state and to
-        receive notifications when the wake lock state is changed.
+        The {{WakeLock}} interface allows the page to acquire and release
+        wake locks of a particular type.
       </p>
       <pre class="idl">
         [SecureContext, Exposed=(DedicatedWorker, Window)]


### PR DESCRIPTION
Since the `onactivechange` and `type` had been removed


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/wake-lock/pull/215.html" title="Last updated on May 23, 2019, 8:18 AM UTC (996ec1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/215/8048c46...Honry:996ec1c.html" title="Last updated on May 23, 2019, 8:18 AM UTC (996ec1c)">Diff</a>