### PR TITLE
Adjust the "Release Wake Lock" algorithm after #209

### DIFF
--- a/index.html
+++ b/index.html
@@ -740,6 +740,15 @@
           |type:WakeLockType|, run these steps <a>in parallel</a>:
         </p>
         <ol class="algorithm" data-link-for="WakeLock">
+          <li>If |record|.{{[[ActiveLocks]]}} does not contain |lockPromise|,
+            abort these steps.
+            <aside class="note">
+              The |lockPromise| only exists in {{[[ActiveLocks]]}} after a wake
+              lock has been acquired, but the {{AbortSignal}}'s algorithm can
+              be run after |lockPromise| has fulfilled, or between each of the
+              parallel steps of {{request()}}'s algorithm.
+            </aside>
+          </li>
           <li>Reject |lockPromise| with an "{{AbortError}}" {{DOMException}}.
             <aside class="note">
               This is a no-op if |lockPromise| has already fulfilled.
@@ -750,14 +759,6 @@
           </li>
           <li>Let |record| be the <a>platform wake lock</a>'s <a>state
             record</a> associated with |document| and |type|.
-          </li>
-          <li>If |record|.{{[[ActiveLocks]]}} does not contain |lockPromise|,
-            abort these steps.
-            <aside class="note">
-              The |lockPromise| only exists in {{[[ActiveLocks]]}} after a
-              wake lock has been acquired, but the {{AbortSignal}}'s algorithm
-              can be run after |lockPromise| has fulfilled.
-            </aside>
           </li>
           <li>Remove |lockPromise| from |record|.{{[[ActiveLocks]]}}.
           </li>


### PR DESCRIPTION
That commit removed all the explicit checks for AbortSignal's aborted flag,
and it relies on "release wake lock" to clean up if the aborted flag is set
between any of the parallel steps in WakeLock.request().

Make the "release wake lock" algorithm abort earlier if a given promise is
not in [[ActiveLocks]], which can happen if AbortController.abort() is
called after querying for permission to get a wake lock but before actually
acquiring it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/216.html" title="Last updated on May 23, 2019, 2:09 PM UTC (fa4ce5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/216/ad4afbd...rakuco:fa4ce5f.html" title="Last updated on May 23, 2019, 2:09 PM UTC (fa4ce5f)">Diff</a>