### PR TITLE
Explain why WakeLock.request() has no "if aborted" step.

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,6 +538,12 @@
                 </ol>
               </li>
             </ol>
+            <aside class="note">
+              There is no <a>if aborted</a> step because the <a>release wake
+              lock</a> algorithm that has been [=AbortSignal/added=] to
+              |options|' |signal| member has taken care of rejecting |promise|
+              with the appropriate {{DOMException}}.
+            </aside>
           </li>
           <li>Return |promise|.
           </li>


### PR DESCRIPTION
Algorithms with an "abort when" part usually are followed by an "if aborted"
step describing what to do if a series of steps was aborted.

Explain why we do not have one here: the only way for the "abort when"
condition to be reached is if one calls `AbortController.abort()`, in which
case we call "release wake lock" and that rejects the promise and does
everything we would do in an "if aborted" step.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/217.html" title="Last updated on May 23, 2019, 3:11 PM UTC (b0a4916)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/217/9eb4c96...rakuco:b0a4916.html" title="Last updated on May 23, 2019, 3:11 PM UTC (b0a4916)">Diff</a>