### PR TITLE
Always reject |lockPromise| in "release wake lock".

### DIFF
--- a/index.html
+++ b/index.html
@@ -751,6 +751,11 @@
           and |type:WakeLockType|, run these steps <a>in parallel</a>:
         </p>
         <ol class="algorithm" data-link-for="WakeLock">
+          <li>Reject |lockPromise| with an "{{AbortError}}" {{DOMException}}.
+            <aside class="note">
+              This is a no-op if |lockPromise| has already fulfilled.
+            </aside>
+          </li>
           <li>If |record|.{{[[ActiveLocks]]}} does not contain |lockPromise|,
           abort these steps.
             <aside class="note">
@@ -758,11 +763,6 @@
               lock has been acquired, but the {{AbortSignal}}'s algorithm can
               be run after |lockPromise| has fulfilled, or between each of the
               parallel steps of {{request()}}'s algorithm.
-            </aside>
-          </li>
-          <li>Reject |lockPromise| with an "{{AbortError}}" {{DOMException}}.
-            <aside class="note">
-              This is a no-op if |lockPromise| has already fulfilled.
             </aside>
           </li>
           <li>Let |document:Document| be the <a>responsible document</a> of the


### PR DESCRIPTION
An existing note already says |lockPromise| may not exist in [[ActiveLocks]]
by the time the "release wake lock" algorithm is called. In that case, we
still need to reject |lockPromise| otherwise it will continue in a pending
state that indicates the lock is acquired.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/221.html" title="Last updated on Jun 9, 2019, 7:42 PM UTC (5db17b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/221/8cd9d34...rakuco:5db17b3.html" title="Last updated on Jun 9, 2019, 7:42 PM UTC (5db17b3)">Diff</a>