### PR TITLE
Specify a default value for |options| in WakeLock.request()

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@
         [SecureContext, Exposed=(DedicatedWorker, Window)]
         interface WakeLock {
           [Exposed=Window] static Promise&lt;PermissionState&gt; requestPermission(WakeLockType type);
-          static Promise&lt;void&gt; request(WakeLockType type, optional WakeLockRequestOptions options);
+          static Promise&lt;void&gt; request(WakeLockType type, optional WakeLockRequestOptions options = {});
         };
       </pre>
       <section data-link-for="WakeLock">


### PR DESCRIPTION
Adapt to https://github.com/heycam/webidl/pull/750, which requires optional
dictionary arguments to have a default value.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/223.html" title="Last updated on Jul 17, 2019, 2:41 PM UTC (d3eeb9d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/223/0e75758...rakuco:d3eeb9d.html" title="Last updated on Jul 17, 2019, 2:41 PM UTC (d3eeb9d)">Diff</a>