### PR TITLE
Release wake lock: Adjust order of the items in the algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -756,6 +756,12 @@
               This is a no-op if |lockPromise| has already fulfilled.
             </aside>
           </li>
+          <li>Let |document:Document| be the <a>responsible document</a> of the
+          <a>current settings object</a>.
+          </li>
+          <li>Let |record| be the <a>platform wake lock</a>'s <a>state
+          record</a> associated with |document| and |type|.
+          </li>
           <li>If |record|.{{[[ActiveLocks]]}} does not contain |lockPromise|,
           abort these steps.
             <aside class="note">
@@ -764,12 +770,6 @@
               be run after |lockPromise| has fulfilled, or between each of the
               parallel steps of {{request()}}'s algorithm.
             </aside>
-          </li>
-          <li>Let |document:Document| be the <a>responsible document</a> of the
-          <a>current settings object</a>.
-          </li>
-          <li>Let |record| be the <a>platform wake lock</a>'s <a>state
-          record</a> associated with |document| and |type|.
           </li>
           <li>Remove |lockPromise| from |record|.{{[[ActiveLocks]]}}.
           </li>


### PR DESCRIPTION
Follow-up to commit c566f974 ('Adjust the "Release Wake Lock" algorithm
after #209'). We were referring to variables like `record` before defining
them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/224.html" title="Last updated on Jul 17, 2019, 3:53 PM UTC (849ec59)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/224/5c34f9a...rakuco:849ec59.html" title="Last updated on Jul 17, 2019, 3:53 PM UTC (849ec59)">Diff</a>