### PR TITLE
Add another condition to WakeLock.request()'s "abort when" block.

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,7 +524,8 @@
           </li>
           <li data-link-for="WakeLockRequestOptions">Run the following steps
           <a>in parallel</a>, but <a>abort when</a> |options|' {{signal}}
-          member is present and its [= AbortSignal/aborted flag =] is set:
+          member is present and its [= AbortSignal/aborted flag =] is set, or
+          |type| is {{WakeLockType["screen"]}} and |document| is <a>hidden</a>:
             <ol>
               <li>Let |state:PermissionState| be the result of awaiting
               <a>obtain permission</a> steps with |type|:


### PR DESCRIPTION
In the WakeLock.request() steps that run in parallel, there was a short
window of time before reaching the "Let success be the result of awaiting
acquire a wake lock with promise and type" substep where `promise` is not
yet in `[[ActiveLocks]]`.

In practice, this means a change in document visibility or loss of document
activity would not cause it to be rejected.

For now, only changes in document visibility really have an effect here, so
extend the "abort when" clause with an extra check.

Fixes #222.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/227.html" title="Last updated on Aug 21, 2019, 12:37 PM UTC (d62662f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/227/15feed0...rakuco:d62662f.html" title="Last updated on Aug 21, 2019, 12:37 PM UTC (d62662f)">Diff</a>