### PR TITLE
Travis: Adapt to Ubuntu Xenial being the default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ branches:
 
 python:
   - "2.7_with_system_site_packages"
+services:
+  - xvfb
 sudo: false
 cache:
   - apt
@@ -21,14 +23,8 @@ addons:
       - python-lxml
       - cmake
       - cmake-data
-      - gcc-4.8
-      - g++-4.8
 before_install:
-  - export CXX="g++-4.8" CC="gcc-4.8"
   - nvm install --lts
-  - "export DISPLAY=:99.0"
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
-  - sh -e /etc/init.d/xvfb start
 install:
  - make travissetup
  - npm install respec-validator


### PR DESCRIPTION
Travis has been switching its VMs from Ubuntu Trusty to Ubuntu Xenial:
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

This seems to be causing problems for us, as the way Xvfb should be used has
changed and our CI was failing with

```
$ /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR
$ sh -e /etc/init.d/xvfb start
sh: 0: Can't open /etc/init.d/xvfb
The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .
```

While here, also try to avoid depending on a GCC version that is too old by
today's standards and probably only made sense when Trusty was in use.