### PR TITLE
Travis: Remove a few extra repositories now that we use Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ cache:
   - apt
 addons:
   apt:
-    sources:
-      - george-edison55-precise-backports
-      - ubuntu-toolchain-r-test
     packages:
       - libwww-perl
       - libcss-dom-perl


### PR DESCRIPTION
We were actually using a few repositories for Ubuntu Precise, which is very
old at this point.

This should fix some warnings shown in Travis builds:

```
W: The repository 'http://ppa.launchpad.net/george-edison55/precise-backports/ubuntu xenial Release' does not have a Release file.
```