### PR TITLE
Remove the note on page visibility handling from WakeLock.request()

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,15 +557,6 @@
           </li>
         </ol>
       </section>
-      <aside class="note">
-        The additional visibility requirement for screen wake lock is to
-        prevent keeping the screen on when the page is not visible, such as
-        when the browser is minimized. As this condition is transient and not
-        under control of the web page, the specification chooses to
-        automatically acquire and release the lock when visibility changes
-        rather than having the page to deal with it, e.g. by re-requesting the
-        lock each time the page becomes visible again.
-      </aside>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
This note was added back in commit 16cd4c749b4 ("Spec update"), but commit
34119d275c ("Handle document visibility") changed the spec in a way that
contradicts the note: we no longer handle visibility changes automatically,
and leave it up to script authors to do that instead.

Whether this is a good idea or at least be made optional is still being
discussed; in the meantime, remove the note since it does not reflect
reality.

Related to #139


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/230.html" title="Last updated on Aug 22, 2019, 2:27 PM UTC (88ca879)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/230/37ad6b0...rakuco:88ca879.html" title="Last updated on Aug 22, 2019, 2:27 PM UTC (88ca879)">Diff</a>