### PR TITLE
Remove paragraph about events and disclosing state in the Security section

### DIFF
--- a/index.html
+++ b/index.html
@@ -811,13 +811,6 @@
         lock application if they determine that the remaining battery capacity
         is low.
       </p>
-      <p data-tests="wakelock-state-is-global.https.html">
-        The ability to observe the global state of a wake lock can create a
-        communication channel between two otherwise isolated {{Document}}
-        objects. One document can request wake lock which changes the global
-        wake lock state, and another document can observe this change by
-        subscribing to events in {{WakeLock}}.
-      </p>
       <p>
         When the <a>user agent</a> does not <a>acquire wake lock</a> even
         though a browsing context has requested it, this can be observed by the


### PR DESCRIPTION
The API no longer has any events and there is no global state that can be
inspected.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/231.html" title="Last updated on Aug 22, 2019, 3:08 PM UTC (129a4df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/231/8233745...rakuco:129a4df.html" title="Last updated on Aug 22, 2019, 3:08 PM UTC (129a4df)">Diff</a>