### PR TITLE
Add an "if aborted" step to WakeLock.request() to deal with hidden documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,6 +513,12 @@
               <li>Resolve |promise| with |lock|.</li>
             </ol>
           </li>
+          <li><a>If aborted</a>, run these steps:
+            <ol>
+               <li>Reject |promise| with a {{"NotAllowedError"}}
+               {{DOMException}}.</li>
+            </ol>
+          </li>
           <li>Return |promise|.
           </li>
         </ol>


### PR DESCRIPTION
This is a follow-up to commit 37ad6b0c ("Add another condition to
WakeLock.request()'s "abort when" block)" that attempted to fix #222.

After #236 we no longer have an `options` argument, but we still need to do
something with `|promise|` if we hit the "abort when" check in the
algorithm.

Add an "if aborted" step that takes care of it, and rejects `|promise|` with
a `NotAllowedError`, the same error that is thrown when a document is
already hidden earlier in `WakeLock.requests()`'s algorithm.

Fixes #239.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/234.html" title="Last updated on Oct 17, 2019, 8:09 AM UTC (9b5c578)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/234/641102a...rakuco:9b5c578.html" title="Last updated on Oct 17, 2019, 8:09 AM UTC (9b5c578)">Diff</a>