### PR TITLE
Fix reference to "a new promise".

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@
         </p>
         <ol class="algorithm">
           <li>Let |promise:Promise&lt;PermissionState&gt;| be <a data-cite=
-          "promises-guide#a-new-promise">a new promise</a>.
+          "webidl#a-new-promise">a new promise</a>.
           </li>
           <li>Return |promise| and run the following steps <a>in parallel</a>:
             <ol>
@@ -456,7 +456,7 @@
         </p>
         <ol class="algorithm">
           <li>Let |promise:Promise| be <a data-cite=
-          "promises-guide#a-new-promise">a new promise</a>.
+          "webidl#a-new-promise">a new promise</a>.
           </li>
           <li>Let |document:Document| be the [=environment settings object /
           responsible document=] of the <a>current settings object</a>.


### PR DESCRIPTION
The old anchor in the TAG's "Writing Promise-Using Specifications" no longer
exists, as the text was moved to the WebIDL specification to fix
heycam/webidl#490.

Reference the right spec to fix our validation checks.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/235.html" title="Last updated on Oct 11, 2019, 2:14 PM UTC (08f87df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/235/ebcc914...rakuco:08f87df.html" title="Last updated on Oct 11, 2019, 2:14 PM UTC (08f87df)">Diff</a>