### PR TITLE
Fix spec validation issues.

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@
         </p>
         <ol class="algorithm">
           <li>Let |promise:Promise&lt;PermissionState&gt;| be <a data-cite=
-          "promises-guide#a-new-promise">a new promise</a>.
+          "webidl#a-new-promise">a new promise</a>.
           </li>
           <li>Return |promise| and run the following steps <a>in parallel</a>:
             <ol>
@@ -456,7 +456,7 @@
         </p>
         <ol class="algorithm">
           <li>Let |promise:Promise| be <a data-cite=
-          "promises-guide#a-new-promise">a new promise</a>.
+          "webidl#a-new-promise">a new promise</a>.
           </li>
           <li>Let |document:Document| be the [=environment settings object /
           responsible document=] of the <a>current settings object</a>.
@@ -548,7 +548,7 @@
             </ol>
             <aside class="note">
               There is no <a>if aborted</a> step because the <a>release wake
-              lock</a> algorithm that has been [=AbortSignal/added=] to
+              lock</a> algorithm that has been [=AbortSignal/add|added=] to
               |options|' |signal| member has taken care of rejecting |promise|
               with the appropriate {{DOMException}}.
             </aside>


### PR DESCRIPTION
* Fix reference to "a new promise". The old anchor in the TAG's "Writing
  Promise-Using Specifications" no longer exists, as the text was moved to
  the WebIDL specification to fix heycam/webidl#490. Fixes

  ```
  page was found but not the anchor from output.html to
  https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise
  ```

* Fix the reference to DOM's AbortSignal's "added" definition:

  ```
  ReSpec error: Couldn't match "**added**" to anything in the document or in
  any other document cited in this specification: `dom`, `feature-policy`,
  `fetch`, `html`, `infra`, `permissions`, `url`, `webidl`.
  ```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/236.html" title="Last updated on Oct 11, 2019, 2:33 PM UTC (d21183a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/236/ebcc914...rakuco:d21183a.html" title="Last updated on Oct 11, 2019, 2:33 PM UTC (d21183a)">Diff</a>