### PR TITLE
Remove WakeLockEvent and WakeLockEventInit.

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,28 +580,6 @@
         </aside>
       </section>
     </section>
-    <section data-dfn-for="WakeLockEvent" data-link-for="WakeLockEvent">
-      <h2>The <dfn>WakeLockEvent</dfn> interface</h2>
-      <pre class="idl">
-        [SecureContext, Exposed=(DedicatedWorker, Window)]
-        interface WakeLockEvent : Event {
-          constructor(DOMString type, WakeLockEventInit init);
-          readonly attribute WakeLockSentinel lock;
-        };
-
-        dictionary WakeLockEventInit : EventInit {
-          required WakeLockSentinel lock;
-        };
-      </pre>
-      <p><a>WakeLockEvent</a> objects indicate that an event has happened to a
-      given <a>WakeLockSentinel</a> object. A <a>WakeLockEvent</a> is
-      dispatched when a <a>WakeLockSentinel</a>'s wake lock is released.</p>
-      <section>
-        <h3>The <dfn>lock</dfn> attribute</h3>
-        <p>The <a>lock</a> attribute is a <a>WakeLockSentinel</a> object whose
-        wake lock has been released.</p>
-      </section>
-    </section>
     <section>
       <h2>
         Managing Wake Locks
@@ -824,10 +802,8 @@
               </li>
             </ol>
           </li>
-          <li><a>Fire an event</a> named "`release`" at |lock| using
-          <a>WakeLockEvent</a> with its <a
-          data-link-for="WakeLockEvent">lock</a> attribute initialized to
-          |sentinel|.</li>
+          <li><a>Queue a task</a> to <a>fire an event</a> named "`release`" at
+          |lock|.</li>
         </ol>
       </section>
     </section>
@@ -883,7 +859,7 @@
 
           const listener = (ev) => {
             checkbox.checked = false;
-            ev.lock.removeEventListener('release', listener);
+            ev.target.removeEventListener('release', listener);
           };
 
           lock.addEventListener('release', listener);


### PR DESCRIPTION
Per https://w3ctag.github.io/design-principles/#state-and-subclassing, we do
not really need a custom event class here.

`WakeLockEvent` has a single attribute, `lock`, that points to the event
target. That's exactly what `Event.target` also does, so we can just create
a simple `Event` instance and let the "fire an event" DOM algorithm set
`target` for us to achieve the same thing. In fact, it already does, so
before this commit we had

    ev.lock === ev.target

Fixes #238.

---

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1015320)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/242.html" title="Last updated on Oct 18, 2019, 7:54 AM UTC (826e89f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/242/7383aff...rakuco:826e89f.html" title="Last updated on Oct 18, 2019, 7:54 AM UTC (826e89f)">Diff</a>