### PR TITLE
Add a proper explanation for WakeLockSentinel.type

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,10 +541,8 @@
         circumstances under which a given wake lock may be released by the
         <a>user agent</a>.
       </aside>
-      <section>
-        <h3>The <dfn>type</dfn> attribute</h3>
-        <p>The <a>type</a> attribute's getter, when invoked, MUST</p>
-      </section>
+      <p>The <dfn>type</dfn> attribute corresponds to the
+      <a>WakeLockSentinel</a>'s <a>wake lock type</a>.</p>
       <section>
         <h3>The <dfn>release()</dfn> method</h3>
         <p>The <a>release()</a> method, when invoked, MUST run the following


### PR DESCRIPTION
This was missing from commit 821842b ("Rewrite user-visible API"). Add a
short text explaining what the attribute corresponds to.

Closes #240.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/243.html" title="Last updated on Oct 17, 2019, 10:26 AM UTC (c9bb113)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/243/641102a...rakuco:c9bb113.html" title="Last updated on Oct 17, 2019, 10:26 AM UTC (c9bb113)">Diff</a>