### PR TITLE
Make WakeLockPermissionDescriptor.type required.

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@
         </p>
         <pre class="idl" data-cite="permissions">
           dictionary WakeLockPermissionDescriptor : PermissionDescriptor {
-            WakeLockType type;
+            required WakeLockType type;
           };
         </pre>
         <p>


### PR DESCRIPTION
Different wake lock types have different permission models, so the previous
assumption that not specifying `type` would ask for permission for all wake
lock types does not hold.

The "block a permission" and "obtain permission" algorithms did not have to
be updated, as they were already assuming `type` was valid.

Closes #233.

---

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [x] Chromium (https://chromium-review.googlesource.com/c/chromium/src/+/1864659)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/244.html" title="Last updated on Oct 17, 2019, 12:08 PM UTC (6a0122c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/244/641102a...rakuco:6a0122c.html" title="Last updated on Oct 17, 2019, 12:08 PM UTC (6a0122c)">Diff</a>