### PR TITLE
chore: more accurately capture commitments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ The following tasks have been completed:
 
 Implementation commitment:
 
- * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
- * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
- * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
+ * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=) 
+ * Gecko - Waiting on [standards position](https://github.com/mozilla/standards-positions/issues/210) before committing.
+ * WebKit - Not participating in this working group. 
  


### PR DESCRIPTION
I think this more accurately reflects the state of the world. I've pinged some folks internally to see if we are interested in adding this to Gecko. Be mindful that even if we are interested it could be 1-2 years before we actually get around to implementing (hopefully sooner). 