### PR TITLE
Editorial: ReSpec usage cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,12 +35,11 @@
           w3cid: "39125"
         }],
         github: "https://github.com/w3c/wake-lock/",
-        wg: "Device APIs Working Group",
-        wgURI: "https://www.w3.org/2009/dap/",
-        wgPublicList: "public-device-apis",
+        wg: "Devices and Sensors Working Group",
+        wgURI: "https://www.w3.org/das/",
         wgPatentURI: "https://www.w3.org/2004/01/pp-impl/43696/status",
         testSuiteURI: "https://w3c-test.org/wake-lock/",
-        implementationReportURI: "https://www.w3.org/2009/dap/wiki/ImplementationStatus",
+        implementationReportURI: "https://www.w3.org/wiki/DAS/Implementations",
         otherLinks: [{
           key: 'Quality Assurance Lead',
           data: [{
@@ -84,11 +83,11 @@
         Introduction
       </h2>
       <p>
-        Modern operating systems achieve longer battery life by implementing aggressive power
-        management, meaning that shortly after the lack of user activity, a
-        host device may lower the screen brightness, turn the screen off and
-        even let the CPU go into a deep power state, allowing to sip as little
-        power as possible.
+        Modern operating systems achieve longer battery life by implementing
+        aggressive power management, meaning that shortly after the lack of
+        user activity, a host device may lower the screen brightness, turn the
+        screen off and even let the CPU go into a deep power state, allowing to
+        sip as little power as possible.
       </p>
       <p>
         Though this is great for prolonged battery life, it can sometime hinder
@@ -152,10 +151,11 @@
         types of wake locks as independent.
       </aside>
       <p>
-        A <a>user agent</a> can <dfn data-lt="deny wake lock">deny a wake
-        lock</dfn> of a particular <a>wake lock type</a> for a particular
-        {{Document}} by any implementation-specific reason, for example, a user
-        or platform setting or preference.
+        A <a>user agent</a> can <dfn data-lt=
+        "deny wake lock|denies the wake lock">deny a wake lock</dfn> of a
+        particular <a>wake lock type</a> for a particular {{Document}} by any
+        implementation-specific reason, for example, a user or platform setting
+        or preference.
       </p>
     </section>
     <section data-cite="feature-policy">
@@ -204,8 +204,8 @@
       <p>
         It is recommended that a UA shows some form of unobtrusive notification
         that informs the user when a wake lock is active, as well as provides
-        the user with the means to <a href="#dfn-block-a-permission">block</a>
-        the ongoing operation, or simply dismiss the notification.
+        the user with the means to <a>block</a> the ongoing operation, or
+        simply dismiss the notification.
       </p>
       <section data-dfn-for="WakeLockPermissionDescriptor">
         <h2>
@@ -234,9 +234,9 @@
           Permission algorithms
         </h2>
         <p>
-          To <dfn>block a permission</dfn>, run these steps:
+          To <dfn data-lt="block">block a permission</dfn>, run these steps:
         </p>
-        <ol class="algorithm" data-link-for="WakeLockPermissionDescriptor">
+        <ol class="algorithm">
           <li>Let |document:Document| be the [=environment settings object /
           responsible document=] of the <a>current settings object</a>.
           </li>
@@ -246,7 +246,8 @@
           <li>Set |descriptor|'s <a>permission state</a> to
           {{PermissionState["denied"]}}.
           </li>
-          <li>Let |type| be |descriptor|'s {{type}} member.
+          <li>Let |type| be |descriptor|'s
+          {{WakeLockPermissionDescriptor/type}} member.
           </li>
           <li>Let |record| be the <a>platform wake lock</a>'s <a>state
           record</a> associated with |document| and |type|.
@@ -264,14 +265,15 @@
           these steps <a>in parallel</a>. This async algorithm returns either
           {{PermissionState["granted"]}} or {{PermissionState["denied"]}}.
         </p>
-        <ol class="algorithm" data-link-for="WakeLockPermissionDescriptor">
+        <ol class="algorithm">
           <li>Let |permissionDesc:WakeLockPermissionDescriptor| be a newly
           created {{WakeLockPermissionDescriptor}}.
           </li>
-          <li data-cite="permissions" data-xref-for="PermissionDescriptor">Set
-          |permissionDesc|'s {{ name }} member to "`wake-lock`".
+          <li>Set |permissionDesc|'s {{PermissionDescriptor/name}} member to
+          "`wake-lock`".
           </li>
-          <li>Set |permissionDesc|'s {{type}} to |type|.
+          <li>Set |permissionDesc|'s {{WakeLockPermissionDescriptor/type}} to
+          |type|.
           </li>
           <li>Let |resultPromise:Promise| be the result of running <a>query a
           permission</a> with |permissionDesc|.
@@ -283,15 +285,14 @@
           <li>Otherwise, let |status:PermissionStatus| be the result of
           |resultPromise|.
           </li>
-          <li data-cite="permissions" data-xref-for="PermissionStatus">Let
-          |state:PermissionState| be the value of |status|.{{state}}.
+          <li>Let |state:PermissionState| be the value of
+          |status|.{{PermissionStatus/state}}.
           </li>
           <li>If |state| is {{PermissionState["prompt"]}}, run the following
           steps:
             <ol>
-              <li>If these <a>obtain permission</a> steps were not
-                <a data-cite="html">triggered by user activation</a>, return
-                {{PermissionState["denied"]}}.
+              <li>If these <a>obtain permission</a> steps were not <a>triggered
+              by user activation</a>, return {{PermissionState["denied"]}}.
               </li>
               <li>Return the result of <a>requesting permission to use</a> with
               |permissionDesc|.
@@ -307,9 +308,9 @@
           which means that the <a>obtain permission</a> steps can never be
           <a>triggered by user activation</a>, meaning that in order to use
           wake locks from a dedicated worker, prior permission needs to granted
-          from the <a data-xref-for="">browsing context</a> who created it,
-          e.g. the <a data-xref-for="">browsing context</a> that is exists in
-          the {{DedicatedWorkerGlobalScope}}'s [=WorkerGlobalScope/owner set=].
+          from the <a>browsing context</a> who created it, e.g. the <a>browsing
+          context</a> that is exists in the {{DedicatedWorkerGlobalScope}}'s
+          [=WorkerGlobalScope/owner set=].
         </aside>
       </section>
     </section>
@@ -383,7 +384,7 @@
               The empty <a>list</a>.
             </td>
             <td>
-              A <a>list</a> of <a>WakeLockSentinel</a> objects, representing
+              A <a>list</a> of {{WakeLockSentinel}} objects, representing
               active wake locks associated with the [=environment settings
               object / responsible document=].
             </td>
@@ -392,26 +393,34 @@
       </table>
     </section>
     <section data-dfn-for="Navigator">
-      <h2>Extensions to the <code>Navigator</code> interface</h2>
+      <h2>
+        Extensions to the `Navigator` interface
+      </h2>
       <pre class="idl">
         [SecureContext]
         partial interface Navigator {
           [SameObject] readonly attribute WakeLock wakeLock;
         };
       </pre>
-      <p>The <a>wakeLock</a> attribute's getter, when invoked, MUST return the
-      same instance of the <a>WakeLock</a> object.</p>
+      <p>
+        The <a>wakeLock</a> attribute's getter, when invoked, MUST return the
+        same instance of the <a>WakeLock</a> object.
+      </p>
     </section>
     <section data-dfn-for="WorkerNavigator">
-      <h2>Extensions to the <code>WorkerNavigator</code> interface</h2>
+      <h2>
+        Extensions to the `WorkerNavigator` interface
+      </h2>
       <pre class="idl">
         [SecureContext]
         partial interface WorkerNavigator {
           [SameObject] readonly attribute WakeLock wakeLock;
         };
       </pre>
-      <p>The <a>wakeLock</a> attribute's getter, when invoked, MUST return the
-      same instance of the <a>WakeLock</a> object.
+      <p>
+        The <a>wakeLock</a> attribute's getter, when invoked, MUST return the
+        same instance of the <a>WakeLock</a> object.
+      </p>
     </section>
     <section data-dfn-for="WakeLock">
       <h2>
@@ -431,13 +440,12 @@
         <h3>
           The <dfn>request()</dfn> method
         </h3>
-        <p data-tests="wakelock-api.https.html" data-link-for="WakeLock">
+        <p data-tests="wakelock-api.https.html">
           The <a data-lt="request">request(|type:WakeLockType|)</a> method,
           when invoked, MUST run the following steps:
         </p>
         <ol class="algorithm">
-          <li>Let |promise:Promise| be <a data-cite=
-          "webidl#a-new-promise">a new promise</a>.
+          <li>Let |promise:Promise| be <a>a new promise</a>.
           </li>
           <li>Let |document:Document| be the [=environment settings object /
           responsible document=] of the <a>current settings object</a>.
@@ -446,12 +454,11 @@
               "wakelock-disabled-by-feature-policy.https.sub.html">If
               |document| is not <a>allowed to use</a> the <a>policy-controlled
               feature</a> named "`wake-lock`", reject |promise| with a
-              "{{NotAllowedError}}" {{DOMException}} and return |promise|.
+              {{"NotAllowedError"}} {{DOMException}} and return |promise|.
               </li>
-              <li>If the <a>user agent</a> <a data-lt="deny wake lock">denies
-              the wake lock</a> of this |type| for |document|, reject |promise|
-              with a "{{NotAllowedError}}" {{DOMException}} and return
-              |promise|.
+              <li>If the <a>user agent</a> <a>denies the wake lock</a> of this
+              |type| for |document|, reject |promise| with a
+              {{"NotAllowedError"}} {{DOMException}} and return |promise|.
               </li>
             </ol>
           </li>
@@ -460,12 +467,12 @@
             <ol>
               <li>If the <a>current global object</a>'s
               [=WorkerGlobalScope/owner set=] [= list/is empty =], reject
-              |promise| with a "{{NotAllowedError}}" {{DOMException}} and
+              |promise| with a {{"NotAllowedError"}} {{DOMException}} and
               return |promise|.
               </li>
-              <li data-link-for="">If |type| is {{ WakeLockType["screen"] }},
-              reject |promise| with a "{{NotAllowedError}}" {{DOMException}},
-              and return |promise|.
+              <li>If |type| is {{ WakeLockType["screen"] }}, reject |promise|
+              with a {{"NotAllowedError"}} {{DOMException}}, and return
+              |promise|.
               </li>
             </ol>
           </li>
@@ -473,15 +480,15 @@
           object:
             <ol>
               <li>If the |document|'s [=Document/browsing context=] is `null`,
-              reject |promise| with a "{{NotAllowedError}}" {{DOMException}}
+              reject |promise| with a {{"NotAllowedError"}} {{DOMException}}
               and return |promise|.
               </li>
               <li>If |document| is not [=Document/fully active=], reject
-              |promise| with a "{{NotAllowedError}}" {{DOMException}}, and
+              |promise| with a {{"NotAllowedError"}} {{DOMException}}, and
               return |promise|.
               </li>
               <li>If |type| is {{WakeLockType["screen"] }} and |document| is
-              <a>hidden</a>, reject |promise| with a "{{NotAllowedError}}"
+              <a>hidden</a>, reject |promise| with a {{"NotAllowedError"}}
               {{DOMException}}, and return |promise|.
               </li>
             </ol>
@@ -493,30 +500,34 @@
               <a>obtain permission</a> steps with |type|:
                 <ol>
                   <li>If |state| is {{PermissionState["denied"]}}, then reject
-                  |promise| with a "{{NotAllowedError}}" {{DOMException}}, and
+                  |promise| with a {{"NotAllowedError"}} {{DOMException}}, and
                   abort these steps.
                   </li>
                 </ol>
               </li>
-              <li>Let |lock:WakeLockSentinel| be a new <a>WakeLockSentinel</a>
-              object with its <a data-link-for="WakeLockSentinel">type</a>
-              attribute set to |type|.</li>
+              <li>Let |lock:WakeLockSentinel| be a new {{WakeLockSentinel}}
+              object with its {{WakeLockSentinel/type}} attribute set to
+              |type|.
+              </li>
               <li>Let |success:boolean| be the result of awaiting <a>acquire a
               wake lock</a> with |lock| and |type|:
                 <ol>
                   <li>If |success| is `false` then reject |promise| with a
-                  "{{NotAllowedError}}" {{DOMException}}, and abort these
+                  {{"NotAllowedError"}} {{DOMException}}, and abort these
                   steps.
                   </li>
                 </ol>
               </li>
-              <li>Resolve |promise| with |lock|.</li>
+              <li>Resolve |promise| with |lock|.
+              </li>
             </ol>
           </li>
-          <li><a>If aborted</a>, run these steps:
+          <li>
+            <a>If aborted</a>, run these steps:
             <ol>
-               <li>Reject |promise| with a {{"NotAllowedError"}}
-               {{DOMException}}.</li>
+              <li>Reject |promise| with a {{"NotAllowedError"}}
+              {{DOMException}}.
+              </li>
             </ol>
           </li>
           <li>Return |promise|.
@@ -524,8 +535,10 @@
         </ol>
       </section>
     </section>
-    <section data-dfn-for="WakeLockSentinel" data-link-for="WakeLockSentinel">
-      <h2>The <dfn>WakeLockSentinel</dfn> interface</h2>
+    <section data-dfn-for="WakeLockSentinel">
+      <h2>
+        The <dfn>WakeLockSentinel</dfn> interface
+      </h2>
       <pre class="idl">
         [SecureContext, Exposed=(DedicatedWorker, Window)]
         interface WakeLockSentinel : EventTarget {
@@ -534,51 +547,67 @@
           attribute EventHandler onrelease;
         };
       </pre>
-      <p>A <a>WakeLockSentinel</a> object provides a handle to a <a>platform
-      wake lock</a>, and it holds on to it until it is either manually released
-      or until the underlying <a>platform wake lock</a> is released. Its
-      existence keeps a <a>platform wake lock</a> for a given <a>wake lock
-      type</a> active, and releasing all
-      <a>WakeLockSentinel</a> instances of a given <a>wake lock type</a> will
-      cause the underlying <a>platform wake lock</a> to be released.
+      <p>
+        A {{WakeLockSentinel}} object provides a handle to a <a>platform wake
+        lock</a>, and it holds on to it until it is either manually released or
+        until the underlying <a>platform wake lock</a> is released. Its
+        existence keeps a <a>platform wake lock</a> for a given <a>wake lock
+        type</a> active, and releasing all {{WakeLockSentinel}} instances of a
+        given <a>wake lock type</a> will cause the underlying <a>platform wake
+        lock</a> to be released.
+      </p>
       <aside class="note">
         See <a>auto-releasing wake locks</a>, <a>handling document loss of full
         activity</a> and <a>handling document loss of visibility</a> for
         circumstances under which a given wake lock may be released by the
         <a>user agent</a>.
       </aside>
-      <p>The <dfn>type</dfn> attribute corresponds to the
-      <a>WakeLockSentinel</a>'s <a>wake lock type</a>.</p>
+      <p>
+        The <dfn>type</dfn> attribute corresponds to the {{WakeLockSentinel}}'s
+        <a>wake lock type</a>.
+      </p>
       <section>
-        <h3>The <dfn>release()</dfn> method</h3>
-        <p>The <a>release()</a> method, when invoked, MUST run the following
-        steps:</p>
+        <h3>
+          The <dfn>release()</dfn> method
+        </h3>
+        <p>
+          The {{WakeLockSentinel/release()}} method, when invoked, MUST run the
+          following steps:
+        </p>
         <ol class="algorithm">
-          <li>Let |promise:Promise| be <a>a new promise</a>.</li>
+          <li>Let |promise:Promise| be <a>a new promise</a>.
+          </li>
           <li>Run the following steps <a>in parallel</a>:
             <ol>
               <li>Run <a>release wake lock</a> with |lock:WakeLockSentinel| set
               to this object and |type:WakeLockType| set to the value of this
-              object's <a>type</a> attribute.</li>
-              <li>Resolve |promise|.</li>
+              object's {{WakeLockSentinel/type}} attribute.
+              </li>
+              <li>Resolve |promise|.
+              </li>
             </ol>
           </li>
-          <li>Return |promise|.</li>
+          <li>Return |promise|.
+          </li>
         </ol>
       </section>
       <section>
-        <h3>The <dfn>onrelease</dfn> attribute</h3>
+        <h3>
+          The <dfn>onrelease</dfn> attribute
+        </h3>
         <p>
-          The <a>onrelease</a> attribute is an <a>event handler</a> whose
-          corresponding <a>event handler event type</a> is
+          The {{WakeLockSentinel/onrelease}} attribute is an <a>event
+          handler</a> whose corresponding <a>event handler event type</a> is
           <code>release</code>.
         </p>
-        <p>It is used to notify scripts that a given <a>WakeLockSentinel</a>
-        object's handle has been released, either due to the
-        <a>release()</a> method being called or because the wake lock was
-        released by the <a>user agent</a>.</p>
+        <p>
+          It is used to notify scripts that a given {{WakeLockSentinel}}
+          object's handle has been released, either due to the
+          {{WakeLockSentinel/release()}} method being called or because the
+          wake lock was released by the <a>user agent</a>.
+        </p>
         <aside class="note">
-          A <a>WakeLockSentinel</a> object's handle being released does not
+          A {{WakeLockSentinel}} object's handle being released does not
           necessarily mean the <a>platform wake lock</a> for a given <a>wake
           lock type</a> was released. That depends on the <a>platform wake
           lock</a>'s {{[[ActiveLocks]]}} internal slot. See <a>release a wake
@@ -659,9 +688,9 @@
           <li>Let |document:Document| be the [=environment settings object /
           responsible document=] of the <a>current settings object</a>.
           </li>
-          <li data-link-for="WakeLockType">Let |screenRecord| be the
-          <a>platform wake lock</a>'s <a>state record</a> associated with
-          |document| and <a>wake lock type</a> {{ WakeLockType["screen"] }}.
+          <li>Let |screenRecord| be the <a>platform wake lock</a>'s <a>state
+          record</a> associated with |document| and <a>wake lock type</a> {{
+          WakeLockType["screen"] }}.
           </li>
           <li>[=list/For each=] |lock:WakeLockSentinel| in
           |screenRecord|.{{[[ActiveLocks]]}}:
@@ -671,9 +700,9 @@
               </li>
             </ol>
           </li>
-          <li data-link-for="WakeLockType">Let |systemRecord| be the
-          <a>platform wake lock</a>'s <a>state record</a> associated with
-          |document| and <a>wake lock type</a> {{ WakeLockType["system"] }}.
+          <li>Let |systemRecord| be the <a>platform wake lock</a>'s <a>state
+          record</a> associated with |document| and <a>wake lock type</a> {{
+          WakeLockType["system"] }}.
           </li>
           <li>[=list/For each=] |lock:WakeLockSentinel| in
           |systemRecord|.{{[[ActiveLocks]]}}:
@@ -739,7 +768,7 @@
           To <dfn>acquire a wake lock</dfn> for a given |lock:WakeLockSentinel|
           and |type:WakeLockType|, run these steps <a>in parallel</a>:
         </p>
-        <ol class="algorithm" data-link-for="WakeLock">
+        <ol class="algorithm">
           <li>If the wake lock for type |type| is not <a>applicable</a>, return
           `false`.
           </li>
@@ -774,15 +803,15 @@
           To <dfn>release a wake lock</dfn> for a given |lock:WakeLockSentinel|
           and |type:WakeLockType|, run these steps <a>in parallel</a>:
         </p>
-        <ol class="algorithm" data-link-for="WakeLock">
+        <ol class="algorithm">
           <li>Let |document:Document| be the [=environment settings object /
           responsible document=] of the <a>current settings object</a>.
           </li>
           <li>Let |record| be the <a>platform wake lock</a>'s <a>state
           record</a> associated with |document| and |type|.
           </li>
-          <li>If |record|.{{[[ActiveLocks]]}} does not contain |lock|,
-          abort these steps.
+          <li>If |record|.{{[[ActiveLocks]]}} does not contain |lock|, abort
+          these steps.
           </li>
           <li>Remove |lock| from |record|.{{[[ActiveLocks]]}}.
           </li>
@@ -808,8 +837,10 @@
               </li>
             </ol>
           </li>
-          <li><a>Queue a task</a> to <a>fire an event</a> named "`release`" at
-          |lock|.</li>
+          <li>
+            <a>Queue a task</a> to <a>fire an event</a> named "`release`" at
+            |lock|.
+          </li>
         </ol>
       </section>
     </section>
@@ -843,7 +874,7 @@
       </h2>
       <pre class="example js" title="Acquires and releases a screen wake lock">
         function tryKeepScreenAlive(minutes) {
-          navigator.wakeLock.request("screen").then(lock => {
+          navigator.wakeLock.request("screen").then(lock =&gt; {
             setTimeout(() =&gt; lock.release(), minutes * 60 * 1000);
           });
         }
@@ -860,10 +891,10 @@
         checkbox.setAttribute("type", "checkbox");
         document.body.appendChild(checkbox);
 
-        navigator.wakeLock.request("screen").then(lock => {
+        navigator.wakeLock.request("screen").then(lock =&gt; {
           checkbox.checked = true;
 
-          const listener = (ev) => {
+          const listener = (ev) =&gt; {
             checkbox.checked = false;
             ev.target.removeEventListener('release', listener);
           };


### PR DESCRIPTION
Quick cleanup and tidy. No substantive changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 25, 2019, 4:37 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fwake-lock%2Fab9cdc4d8cb1eff9d4251130dbaf4793aeb62d5d%2Findex.html%3FisPreview%3Dtrue)

```
Navigation Timeout Exceeded: 30000ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/wake-lock%23248.)._
</details>
