### PR TITLE
Update and modernize example #2.

### DIFF
--- a/index.html
+++ b/index.html
@@ -615,6 +615,10 @@
           lock</a>'s {{[[ActiveLocks]]}} internal slot. See <a>release a wake
           lock</a>.
         </aside>
+        <aside class="note">
+          [[[#onrelease-example]]] contains an example of how to use the
+          {{WakeLockSentinel/onrelease}} event handler.
+        </aside>
       </section>
     </section>
     <section>
@@ -888,21 +892,14 @@
         on a checkbox, but updates the checkbox checked state in case the wake
         lock state changes:
       </p>
-      <pre class="example js">
+      <pre class="example js" id="onrelease-example">
         const checkbox = document.createElement("input");
         checkbox.setAttribute("type", "checkbox");
         document.body.appendChild(checkbox);
 
-        navigator.wakeLock.request("screen").then(lock =&gt; {
-          checkbox.checked = true;
-
-          const listener = (ev) =&gt; {
-            checkbox.checked = false;
-            ev.target.removeEventListener('release', listener);
-          };
-
-          lock.addEventListener('release', listener);
-        });
+        const sentinel = await navigator.wakeLock.request("screen");
+        checkbox.checked = true;
+        sentinel.onrelease = () =&gt; checkbox.checked = false;
       </pre>
       <p>
         In this example, two different wake lock requests are created and


### PR DESCRIPTION
Simplify it a little but, use `await` instead of `.then()`. Also replace
`addEventListener()` with a direct assignment of the `onrelease` attribute
to make the example easier to find.

Closes #250.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/251.html" title="Last updated on Feb 7, 2020, 1:04 PM UTC (3699524)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/251/ace16d3...rakuco:3699524.html" title="Last updated on Feb 7, 2020, 1:04 PM UTC (3699524)">Diff</a>