### PR TITLE
editorial: Use new HTML activation model

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,8 +291,11 @@
           <li>If |state| is {{PermissionState["prompt"]}}, run the following
           steps:
             <ol>
-              <li>If these <a>obtain permission</a> steps were not <a>triggered
-              by user activation</a>, return {{PermissionState["denied"]}}.
+              <li>If the <a>current global object</a> is not a {{Window}},
+              return {{PermissionState["denied"]}}.
+              </li>
+              <li>If the <a>current global object</a> does not have [=transient
+              activation=], return {{PermissionState["denied"]}}.
               </li>
               <li>Return the result of <a>requesting permission to use</a> with
               |permissionDesc|.
@@ -304,13 +307,12 @@
         </ol>
         <aside class="note">
           In the case the steps are run from a dedicated worker, then the
-          <a>current global object</a> is a {{DedicatedWorkerGlobalScope}},
-          which means that the <a>obtain permission</a> steps can never be
-          <a>triggered by user activation</a>, meaning that in order to use
-          wake locks from a dedicated worker, prior permission needs to granted
-          from the <a>browsing context</a> who created it, e.g. the <a>browsing
-          context</a> that is exists in the {{DedicatedWorkerGlobalScope}}'s
-          [=WorkerGlobalScope/owner set=].
+          <a>current global object</a> is a {{DedicatedWorkerGlobalScope}}, for
+          which the concept of [=transient activation=] is not defined.
+          Consequently, in order to use wake locks from a dedicated worker,
+          prior permission needs to be granted from the <a>browsing context</a>
+          who created it, e.g. the <a>browsing context</a> that is exists in
+          the {{DedicatedWorkerGlobalScope}}'s [=WorkerGlobalScope/owner set=].
         </aside>
       </section>
     </section>


### PR DESCRIPTION
Adapt to whatwg/html#5129 and follow the spec editing advice from
https://docs.google.com/document/d/14wT89JZ0qeRehXGkcn3_meXxjvlHKgM9d7aJj80kQcQ/edit ("User
Activation: Guidance for spec authors") by replacing "triggered by user
activation" with "the current global object has transient activation".

This makes ReSpec happy again.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/252.html" title="Last updated on Feb 5, 2020, 3:47 PM UTC (097b84d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wake-lock/252/92a2f7a...rakuco:097b84d.html" title="Last updated on Feb 5, 2020, 3:47 PM UTC (097b84d)">Diff</a>