### PR TITLE
Proof-read after #255.

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,8 +71,8 @@
         incompatible ways.</strong> Vendors interested in implementing this
         specification before it eventually reaches the Candidate Recommendation
         phase should <a href=
-        "https://github.com/w3c/screen-wake-lock/issues">subscribe to the repository
-        on GitHub</a> and take part in the discussions.
+        "https://github.com/w3c/screen-wake-lock/issues">subscribe to the
+        repository on GitHub</a> and take part in the discussions.
       </p>
     </section>
     <section>
@@ -372,7 +372,7 @@
           <li>Return |promise| and run the following steps <a>in parallel</a>:
             <ol>
               <li>
-                <a>abort when</a> |document| is <a>hidden</a>,
+                <a>Abort when</a> |document| is <a>hidden</a>.
               </li>
               <li>Let |state:PermissionState| be the result of awaiting
               <a>obtain permission</a> steps with "`screen-wake-lock`":
@@ -384,7 +384,8 @@
                 </ol>
               </li>
               <li>Let |lock:WakeLockSentinel| be a new {{WakeLockSentinel}}
-              object with its {{WakeLockSentinel/type}} attribute set |type|.
+              object with its {{WakeLockSentinel/type}} attribute set to
+              |type|.
               </li>
               <li>Let |success:boolean| be the result of awaiting <a>acquire a
               wake lock</a> with |lock| and {{WakeLockType/"screen"}}:
@@ -584,7 +585,7 @@
           </li>
           <li>Let |screenRecord| be the <a>platform wake lock</a>'s <a>state
           record</a> associated with |document| and <a>wake lock type</a>
-          {{WakeLockType/"screen"}}.
+          [=screen wake lock=].
           </li>
           <li>[=list/For each=] |lock:WakeLockSentinel| in
           |screenRecord|.{{[[ActiveLocks]]}}:
@@ -618,7 +619,8 @@
           these steps.
           </li>
           <li>Let |screenRecord| be the <a>platform wake lock</a>'s <a>state
-          record</a> associated with <a>wake lock type</a> "screen-wake-lock".
+          record</a> associated with <a>wake lock type</a> [=screen wake
+          lock=].
           </li>
           <li>[=list/For each=] |lock:WakeLockSentinel| in
           |screenRecord|.{{[[ActiveLocks]]}}:
@@ -648,7 +650,7 @@
           <li>Set |active:boolean| to `true` if the <a>platform wake lock</a>
           has an active wake lock for |type|.
           </li>
-          <li>Otherwise, ask the underlying operation system to <a>acquire the
+          <li>Otherwise, ask the underlying operating system to <a>acquire the
           wake lock</a> of type |type| and set |active| to `true` if the
           operation succeeded, or else `false`.
           </li>
@@ -692,7 +694,7 @@
           wake lock</a>'s <a>state record</a>s are all empty, then run the
           following steps <a>in parallel</a>:
             <ol>
-              <li>Ask the underlying operation system to release the wake lock
+              <li>Ask the underlying operating system to release the wake lock
               of type |type| and let |success:boolean| be `true` if the
               operation succeeded, or else `false`.
               </li>


### PR DESCRIPTION
Make some small corrections after the big changes from that pull request.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 1, 2020, 2:48 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fscreen-wake-lock%2Fda51c710e025415794bca05dcee4b0fd3636e84b%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/screen-wake-lock%23260.)._
</details>
