### PR TITLE
Use the `group` configuration option

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,7 @@
           w3cid: "75989"
         },],
         github: "https://github.com/w3c/screen-wake-lock/",
-        wg: "Devices and Sensors Working Group",
-        wgURI: "https://www.w3.org/das/",
-        wgPatentURI: "https://www.w3.org/2004/01/pp-impl/43696/status",
+        group: "das",
         testSuiteURI: "https://w3c-test.org/screen-wake-lock/",
         implementationReportURI: "https://www.w3.org/wiki/DAS/Implementations",
         otherLinks: [{


### PR DESCRIPTION
The wg, wgId, wgURI, and wgPatentURI options are deprecated in favour of
“group”.

See https://lists.w3.org/Archives/Public/spec-prod/2020JulSep/0002.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/pull/265.html" title="Last updated on Jul 23, 2020, 3:46 AM UTC (ac8fcce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/265/b0193f0...ac8fcce.html" title="Last updated on Jul 23, 2020, 3:46 AM UTC (ac8fcce)">Diff</a>