### PR TITLE
Add a Changes section

### DIFF
--- a/index.html
+++ b/index.html
@@ -812,5 +812,30 @@
         to this work.
       </p>
     </section>
+    <section class="appendix informative" id="changes">
+      <h2>
+        Changes
+      </h2>
+      <p>This section documents the changes since previous publications.</p>
+      <section id="changes-20171214">
+        <h2>Changes since the 14 December 2017 CR</h2>
+        <ul>
+          <li>Convert the document to purely screen wake lock, and move system lock to a new specification.</li>
+          <li>Rewrite user-visible API.</li>
+          <li>Add an <a>if aborted</a> step to <code>WakeLock.request()</code> to deal with hidden documents.</li>
+          <li>Add an IDL Index.</li>
+          <li>Remove duplicate normative statements.</li>
+          <li>Modernize the examples.</li>
+          <li>Use internal slots instead of prose.</li>
+          <li>Add info on when the user agent may <a>release a wake lock</a>.</li>
+          <li>Handle document visibility.</li>
+          <li>Make WakeLock constructable.</li>
+          <li>Integrate optional permission prompting.</li>
+          <li>Handle loss of full activity, as well as running in workers.</li>
+          <li>Rewrite the introduction section.</li>
+          <li>Rename Feature Policy to Permissions Policy.</li>
+        </ul>
+      </section>
+    </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -829,7 +829,7 @@
           <li>Use internal slots instead of prose.</li>
           <li>Add info on when the user agent may <a>release a wake lock</a>.</li>
           <li>Handle document visibility.</li>
-          <li>Make WakeLock constructable.</li>
+          <li>Make {{ScreenWakeLock}} constructable.</li>
           <li>Integrate optional permission prompting.</li>
           <li>Handle loss of full activity, as well as running in workers.</li>
           <li>Rewrite the introduction section.</li>


### PR DESCRIPTION
I didn't use the [rs-changelog](https://github.com/w3c/respec/wiki/rs-changelog) since filtering the commit messages feels a bit troublesome (to me), and I personally prefer to list them in the section using HTML directly (and I do this in other specs as well).

I used imperative mood in the changes section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/pull/269.html" title="Last updated on Aug 6, 2020, 9:24 AM UTC (8f3e9b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/269/854cd93...8f3e9b5.html" title="Last updated on Aug 6, 2020, 9:24 AM UTC (8f3e9b5)">Diff</a>