### PR TITLE
Reference the "release a wake lock" algorithm in WakeLockSentinel.release()

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,9 +453,9 @@
           </li>
           <li>Run the following steps <a>in parallel</a>:
             <ol>
-              <li>Run <a>release wake lock</a> with |lock:WakeLockSentinel| set
-              to this object and |type:WakeLockType| set to the value of this
-              object's {{WakeLockSentinel/type}} attribute.
+              <li>Run <a>release a wake lock</a> with |lock:WakeLockSentinel|
+              set to this object and |type:WakeLockType| set to the value of
+              this object's {{WakeLockSentinel/type}} attribute.
               </li>
               <li>Resolve |promise|.
               </li>


### PR DESCRIPTION
We were referring to the "release wake lock" definition instead, which did
not make much sense in this context.

Fixes #271.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/275.html" title="Last updated on Aug 17, 2020, 2:19 PM UTC (4ec6655)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/275/699adb0...rakuco:4ec6655.html" title="Last updated on Aug 17, 2020, 2:19 PM UTC (4ec6655)">Diff</a>