### PR TITLE
Add WakeLockSentinel.released.

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,8 +701,6 @@
           </li>
           <li>Remove |lock| from |record|.{{[[ActiveLocks]]}}.
           </li>
-          <li>Set |lock|.{{WakeLockSentinel/released}} to `true`.
-          </li>
           <li>If the internal slot {{[[ActiveLocks]]}} of all the <a>platform
           wake lock</a>'s <a>state record</a>s are all empty, then run the
           following steps <a>in parallel</a>:
@@ -726,8 +724,14 @@
             </ol>
           </li>
           <li>
-            <a>Queue a task</a> to <a>fire an event</a> named "`release`" at
-            |lock|.
+            <a>Queue a task</a> to run the following steps:
+            <ol>
+              <li>Set |lock|.{{WakeLockSentinel/released}} to `true`.
+              </li>
+              <li>
+                <a>Fire an event</a> named "`release`" at |lock|.
+              </li>
+            </ol>
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -416,6 +416,7 @@
       <pre class="idl">
         [SecureContext, Exposed=(Window)]
         interface WakeLockSentinel : EventTarget {
+          readonly attribute boolean released;
           readonly attribute WakeLockType type;
           Promise&lt;undefined&gt; release();
           attribute EventHandler onrelease;
@@ -437,6 +438,12 @@
         <a>user agent</a>.
       </aside>
       <p>
+        The <dfn>released</dfn> attribute indicates whether the
+        {{WakeLockSentinel}} has been released. Its initial value is `false`.
+        Once a {{WakeLockSentinel}} is released, {{WakeLockSentinel/released}}
+        becomes `true`, and the value never changes again.
+      </p>
+      <p>
         The <dfn>type</dfn> attribute corresponds to the {{WakeLockSentinel}}'s
         <a>wake lock type</a>.
       </p>
@@ -449,7 +456,10 @@
           following steps:
         </p>
         <ol class="algorithm">
-          <li>Let |promise:Promise| be <a>a new promise</a>.
+          <li>If this object's {{WakeLockSentinel/released}} attribute is
+          `true`, return <a>a promise resolved with</a> `undefined`.
+          </li>
+          <li>Otherwise, let |promise:Promise| be <a>a new promise</a>.
           </li>
           <li>Run the following steps <a>in parallel</a>:
             <ol>
@@ -691,6 +701,8 @@
           </li>
           <li>Remove |lock| from |record|.{{[[ActiveLocks]]}}.
           </li>
+          <li>Set |lock|.{{WakeLockSentinel/released}} to `true`.
+          </li>
           <li>If the internal slot {{[[ActiveLocks]]}} of all the <a>platform
           wake lock</a>'s <a>state record</a>s are all empty, then run the
           following steps <a>in parallel</a>:
@@ -768,8 +780,8 @@
         document.body.appendChild(checkbox);
 
         const sentinel = await navigator.wakeLock.request("screen");
-        checkbox.checked = true;
-        sentinel.onrelease = () =&gt; checkbox.checked = false;
+        checkbox.checked = !sentinel.released;
+        sentinel.onrelease = () =&gt; checkbox.checked = !sentinel.released;
       </pre>
       <p>
         In this example, two different wake lock requests are created and


### PR DESCRIPTION
`released` is a read-only boolean attribute that indicates whether a
WakeLockSentinel has been released. Its initial value is false, and it is
changed to true by the "release a wake lock" algorithm.

Fixes #272.

The following tasks have been completed:

 * [x] Modified Web platform tests (https://github.com/web-platform-tests/wpt/pull/25271)

Implementation commitment:

 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1122518) 
 * [x] Gecko (no activity past https://bugzilla.mozilla.org/show_bug.cgi?id=1589554)
 * WebKit - Not participating in this working group.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/279.html" title="Last updated on Aug 28, 2020, 12:51 PM UTC (c1f1901)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/279/c6f03d2...rakuco:c1f1901.html" title="Last updated on Aug 28, 2020, 12:51 PM UTC (c1f1901)">Diff</a>