### PR TITLE
editorial: Add internal slots to WakeLockSentinel.

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,8 +508,8 @@
           following steps:
         </p>
         <ol class="algorithm">
-          <li>If this object's {{WakeLockSentinel/released}} attribute is
-          `true`, return <a>a promise resolved with</a> `undefined`.
+          <li>If this object's {{[[Released]]}} internal slot is `true`, return
+          <a>a promise resolved with</a> `undefined`.
           </li>
           <li>Otherwise, let |promise:Promise| be <a>a new promise</a>.
           </li>

--- a/index.html
+++ b/index.html
@@ -437,16 +437,68 @@
         circumstances under which a given wake lock may be released by the
         <a>user agent</a>.
       </aside>
-      <p>
-        The <dfn>released</dfn> attribute indicates whether the
-        {{WakeLockSentinel}} has been released. Its initial value is `false`.
-        Once a {{WakeLockSentinel}} is released, {{WakeLockSentinel/released}}
-        becomes `true`, and the value never changes again.
-      </p>
-      <p>
-        The <dfn>type</dfn> attribute corresponds to the {{WakeLockSentinel}}'s
-        <a>wake lock type</a>.
-      </p>
+      <section>
+        <h3>
+          Internal slots
+        </h3>
+        <p>
+          {{WakeLockSentinel}} instances are created with the following
+          <a data-cite=
+          "ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal
+          slots</a>:
+        </p>
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>
+                Internal slot
+              </th>
+              <th>
+                Initial value
+              </th>
+              <th>
+                Description (non-normative)
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <dfn>[[\Released]]</dfn>
+              </td>
+              <td>
+                `false`
+              </td>
+              <td>
+                Whether the given {{WakeLockSentinel}} has been released.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h3>
+          The <dfn>released</dfn> attribute
+        </h3>
+        <p>
+          The {{WakeLockSentinel/released}} attribute's getter returns the
+          value of the {{[[Released]]}} internal slot.
+        </p>
+        <aside class="note">
+          Once a {{WakeLockSentinel}} is released,
+          {{WakeLockSentinel/released}} becomes `true`, and the value never
+          changes again.
+        </aside>
+      </section>
+      <section>
+        <h3>
+          The <dfn>type</dfn> attribute
+        </h3>
+        <p>
+          The {{WakeLockSentinel/type}} attribute corresponds to the
+          {{WakeLockSentinel}}'s <a>wake lock type</a>.
+        </p>
+      </section>
       <section>
         <h3>
           The <dfn>release()</dfn> method
@@ -726,7 +778,7 @@
           <li>
             <a>Queue a task</a> to run the following steps:
             <ol>
-              <li>Set |lock|.{{WakeLockSentinel/released}} to `true`.
+              <li>Set |lock|'s {{[[Released]]}} internal slot to `true`.
               </li>
               <li>
                 <a>Fire an event</a> named "`release`" at |lock|.


### PR DESCRIPTION
Adopt some post-commit suggestions posted to #279:
* `WakeLockSentinel.released` is a read-only attribute, so saying "change
  its value" in the "release a wake lock" algorithm is a contradiction.
  Instead, add a `[[Released]]` internal slot to WakeLockSentinel and
  change that instead, and change `released`'s description to mention the
  slot.
* While here, add a separate section to each WakeLockSentinel attribute.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/280.html" title="Last updated on Aug 28, 2020, 2:34 PM UTC (e1ec002)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/280/0dc9cf4...rakuco:e1ec002.html" title="Last updated on Aug 28, 2020, 2:34 PM UTC (e1ec002)">Diff</a>