### PR TITLE
Ensure the release operation is valid WebIDL

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,7 +418,7 @@
         interface WakeLockSentinel : EventTarget {
           readonly attribute boolean released;
           readonly attribute WakeLockType type;
-          Promise&lt;undefined&gt; release();
+          Promise&lt;void&gt; release();
           attribute EventHandler onrelease;
         };
       </pre>


### PR DESCRIPTION
To represent that the release operation returns javascript undefined, the correct way is to mark the resolve type of Promise as void. Without this change the idl snippet will not parse with a spec compliant WebIDL parser.

See https://heycam.github.io/webidl/#index-prod-PromiseType


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/realityforge/screen-wake-lock/pull/283.html" title="Last updated on Sep 10, 2020, 10:52 PM UTC (a84389b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/283/e40b884...realityforge:a84389b.html" title="Last updated on Sep 10, 2020, 10:52 PM UTC (a84389b)">Diff</a>