### PR TITLE
chore: add lang="en"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset='utf-8'>
     <title>


### PR DESCRIPTION
The i18n WG [recommends](https://www.w3.org/International/techniques/authoring-html.en?open=language&open=textprocessing#textprocessing) always declaring the default language for text in the page using attributes on the `html` tag.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/pull/289.html" title="Last updated on Sep 27, 2020, 3:38 AM UTC (3d209f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/289/0b715f7...3d209f0.html" title="Last updated on Sep 27, 2020, 3:38 AM UTC (3d209f0)">Diff</a>