### PR TITLE
Make "type" an optional parameter for WakeLock.request().

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -62,8 +62,9 @@ if (lock.released === false) {
 
 ### Requesting permission to use WakeLocks
 To use the API, one must request access via
-`navigator.wakeLock.request("screen")`. This returns a promise which, if
-allowed by the user, resolves with a `WakeLockSentinel`.
+`navigator.wakeLock.request("screen")` (_"screen"_ is optional). This
+returns a promise which, if allowed by the user, resolves with a
+`WakeLockSentinel`.
 
 ```js
 let sentinel;

--- a/explainer.md
+++ b/explainer.md
@@ -62,7 +62,7 @@ if (lock.released === false) {
 
 ### Requesting permission to use WakeLocks
 To use the API, one must request access via
-`navigator.wakeLock.request("screen")` (_"screen"_ is optional). This
+`navigator.wakeLock.request("screen")` (`"screen"` is optional). This
 returns a promise which, if allowed by the user, resolves with a
 `WakeLockSentinel`.
 

--- a/index.html
+++ b/index.html
@@ -326,7 +326,7 @@
       <pre class="idl">
         [SecureContext, Exposed=(Window)]
         interface WakeLock {
-          Promise&lt;WakeLockSentinel&gt; request(WakeLockType type);
+          Promise&lt;WakeLockSentinel&gt; request(optional WakeLockType type = "screen");
         };
       </pre>
       <section>


### PR DESCRIPTION
And make it default to "screen". Existing code continues to work, while new
code can also call `navigator.wakeLock.request()` to request a screen wake
lock.

Issues #253, #255 and #288 indicate that there is a preference for making
`type` an optional parameter that just got overlooked.

The following tasks have been completed:

 * [x] Modified Web platform tests (https://github.com/web-platform-tests/wpt/pull/25946)

Implementation commitment:

 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1133696) 
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1589554)
 * WebKit - Not participating in this working group.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/291.html" title="Last updated on Oct 5, 2020, 7:17 AM UTC (b00fff3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/291/f89b85a...rakuco:b00fff3.html" title="Last updated on Oct 5, 2020, 7:17 AM UTC (b00fff3)">Diff</a>