### PR TITLE
Stop returning a boolean in the "acquire a wake lock" algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -709,8 +709,8 @@
           and |type:WakeLockType|, run these steps <a>in parallel</a>:
         </p>
         <ol class="algorithm">
-          <li>If the wake lock for type |type| is not <a>applicable</a>, return
-          `false`.
+          <li>If the wake lock for type |type| is not <a>applicable</a>, abort
+          these steps.
           </li>
           <li>If the <a>platform wake lock</a> has an active lock for |type|,
           abort these steps.


### PR DESCRIPTION
Follow-up to #285 ('Stop checking if "acquire the wake lock" succeeds').
That change stopped expecting the algorithm to return true or false, but its
first step was still returning `false` rather than just aborting the rest of
the steps.

This change should have no user-visible effects.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/294.html" title="Last updated on Feb 3, 2021, 1:50 PM UTC (ae261b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/294/58a7bb0...rakuco:ae261b9.html" title="Last updated on Feb 3, 2021, 1:50 PM UTC (ae261b9)">Diff</a>