### PR TITLE
Adjust state record selection in "Managing Wake Locks".

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,7 +650,7 @@
           </li>
           <li>Let |screenRecord| be the <a>platform wake lock</a>'s <a>state
           record</a> associated with |document| and <a>wake lock type</a>
-          [=screen wake lock=].
+          {{WakeLockType/"screen"}}.
           </li>
           <li>[=list/For each=] |lock:WakeLockSentinel| in
           |screenRecord|.{{[[ActiveLocks]]}}:
@@ -684,8 +684,8 @@
           these steps.
           </li>
           <li>Let |screenRecord| be the <a>platform wake lock</a>'s <a>state
-          record</a> associated with <a>wake lock type</a> [=screen wake
-          lock=].
+          record</a> associated with |document| and <a>wake lock type</a>
+          {{WakeLockType/"screen"}}.
           </li>
           <li>[=list/For each=] |lock:WakeLockSentinel| in
           |screenRecord|.{{[[ActiveLocks]]}}:


### PR DESCRIPTION
* Use right notation for `WakeLockType` in the "Handling document loss of
  {full activity,visibility}" sections. We were referencing the "screen wake
  lock" definition rather than the "screen" WakeLockType.

* Explicitly mention we need the state record associated with `|document|`
  in "Handling document loss of visibility" like we do in "Handling document
  loss of full activity".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/295.html" title="Last updated on Feb 4, 2021, 9:43 AM UTC (79cf517)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/295/720f975...rakuco:79cf517.html" title="Last updated on Feb 4, 2021, 9:43 AM UTC (79cf517)">Diff</a>