### PR TITLE
editorial: Formally define a permission revocation algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,8 +173,9 @@
       <p>
         It is RECOMMENDED that a user agent show some form of unobtrusive
         notification that informs the user when a wake lock is active, as well
-        as provides the user with the means to <a>block</a> the ongoing
-        operation, or simply dismiss the notification.
+        as provides the user with the means to [=screen wake lock permission
+        revocation algorithm|block=] the ongoing operation, or simply dismiss
+        the notification.
       </p>
       <section>
         <h2>
@@ -190,17 +191,13 @@
           Permission algorithms
         </h2>
         <p data-tests="wakelockpermissiondescriptor.https.html">
-          To <dfn data-lt="block">block a permission</dfn>, run these steps:
+          The `"screen-wake-lock"` <a>powerful feature</a> defines a
+          <a>permission revocation algorithm</a>. To invoke the <dfn>Screen
+          Wake Lock permission revocation algorithm</dfn>, run these steps:
         </p>
         <ol class="algorithm">
           <li>Let |document:Document| be the [=environment settings object /
           responsible document=] of the <a>current settings object</a>.
-          </li>
-          <li>Let |descriptor:PermissionDescriptor| be an instance of
-          {{PermissionDescriptor}}.
-          </li>
-          <li>Set |descriptor|'s <a>permission state</a> to
-          {{PermissionState/"denied"}}.
           </li>
           <li>Let |record| be the <a>platform wake lock</a>'s <a>state
           record</a> associated with |document| and <a>wake lock type</a>


### PR DESCRIPTION
The "block a permission" algorithm was manipulating a `PermissionDescriptor`
instance to change its "permission state" and then release any existing
locks. However, the Permissions spec does not actually define a way for
other specifications to modify a PermissionDescriptor's permission state.

What we want here is to react to a user-triggered change that sets the
permission state to "denied". That's what the "permission revocation
algorithm" hook in the Permissions spec does, so instead of defining a
"block a permission" algorithm define a custom "permission revocation
algorithm" instead.

Related to #198 -- one of @marcoscaceres' comments is about hooking more of
the permissions text directly into the Permissions spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/297.html" title="Last updated on Feb 4, 2021, 2:27 PM UTC (50b0b03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/297/a17d89b...rakuco:50b0b03.html" title="Last updated on Feb 4, 2021, 2:27 PM UTC (50b0b03)">Diff</a>