### PR TITLE
editorial: Remove the "obtain a permission" algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,31 +217,6 @@
             </ol>
           </li>
         </ol>
-        <p>
-          To <dfn>obtain permission</dfn> for <a>wake lock type</a> |name|, run
-          the following steps. This algorithm returns either
-          {{PermissionState/"granted"}} or {{PermissionState/"denied"}}.
-        </p>
-        <aside class="note">
-          The following algorithm is defined in this specification because the
-          Permissions specification currently lacks integration with the
-          concept of user activation from [[HTML]]. See <a href=
-          "https://github.com/w3c/permissions/issues/194">this issue for more
-          information</a>.
-        </aside>
-        <ol class="algorithm">
-          <li>Let |state:PermissionState| be <a>permission state</a> of the
-          `"screen-wake-lock"` {{PermissionName}}.
-          </li>
-          <li>If |state| is not {{PermissionState/"prompt"}}, return |state|.
-          </li>
-          <li>If the <a>current global object</a> does not have [=transient
-          activation=], return {{PermissionState/"denied"}}.
-          </li>
-          <li>Otherwise, return the result of <a>requesting permission to
-          use</a> the `"screen-wake-lock"` {{PermissionName}}.
-          </li>
-        </ol>
       </section>
     </section>
     <section>
@@ -369,8 +344,8 @@
           </li>
           <li>Run the following steps <a>in parallel</a>:
             <ol>
-              <li>Let |state:PermissionState| be the result of invoking
-              <a>obtain permission</a> with "`screen-wake-lock`".
+              <li>Let |state:PermissionState| be the result of <a>requesting
+              permission to use</a> "`screen-wake-lock`".
               </li>
               <li data-tests="wakelock-request-denied.https.html">If |state| is
               {{PermissionState/"denied"}}, then:


### PR DESCRIPTION
This may have made more sense back when we had a custom
`WakeLockPermissionDescriptor`, but even then this felt like implementing a
custom permission model for no reason.

We are just interested in knowing whether we have permission to request a
wake lock from the platform, and we can use the Permission spec's "request
permission to use" algorithm for that just fine.

One important change is related to checking transient activation: the
"obtain a permission" algorithm essentially denied requests when
"screen-wake-lock"'s permission state was set to "prompt" AND there was no
transient user activation. In general, an API should either always or never
be user-activation gated. Given Blink is the only current implementation of
this spec and it does not currently gate this API on user activation, the
transient user activation check was removed altogether for now.

Together with #297, this fixes #187 and fixes #198.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/298.html" title="Last updated on Jun 2, 2021, 11:22 AM UTC (0221e02)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/298/47bdb3a...rakuco:0221e02.html" title="Last updated on Jun 2, 2021, 11:22 AM UTC (0221e02)">Diff</a>