### PR TITLE
editorial: Define a task source for the tasks run by this specification.

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,6 +253,10 @@
         Concepts and state record
       </h3>
       <p>
+        The <a>task source</a> for the <a>tasks</a> mentioned in this
+        specification is the <dfn>screen wake lock task source</dfn>.
+      </p>
+      <p>
         The term <dfn>platform wake lock</dfn> refers to platform interfaces
         with which the user agent interacts to query state and acquire and
         release a wake lock.
@@ -907,6 +911,8 @@
           <li>Rename Feature Policy to Permissions Policy.
           </li>
           <li>Add <code>WakeLockSentinel.released</code>.
+          </li>
+          <li>Define a task source for tasks in this specification.
           </li>
         </ul>
       </section>


### PR DESCRIPTION
This allows implementations to better decide when to run events and tasks
from this spec in relation to others, and specifying a task source is a
requirement when queuing tasks like we do [1].

[1] https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-for-spec-authors

Rather than picking a generic task source from the HTML spec, we define a
new task source, the "screen wake lock task source", following the current
guidance in w3ctag/design-principles#38 (which is still open).

Implementation commitment:

 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1176157) 
 * WebKit - Not participating in this working group.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/301.html" title="Last updated on Feb 9, 2021, 11:12 AM UTC (fa8693f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/301/2b458c2...rakuco:fa8693f.html" title="Last updated on Feb 9, 2021, 11:12 AM UTC (fa8693f)">Diff</a>