### PR TITLE
Move reference to wakelockpermissiondescriptor.https.html.

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
         <h2>
           The `"screen-wake-lock"` powerful feature
         </h2>
-        <p>
+        <p data-tests="wakelockpermissiondescriptor.https.html">
           The `"screen-wake-lock"` <a>powerful feature</a> enables the
           capability defined by this specification.
         </p>
@@ -190,7 +190,7 @@
         <h2>
           Permission algorithms
         </h2>
-        <p data-tests="wakelockpermissiondescriptor.https.html">
+        <p>
           The `"screen-wake-lock"` <a>powerful feature</a> defines a
           <a>permission revocation algorithm</a>. To invoke the <dfn>Screen
           Wake Lock permission revocation algorithm</dfn>, run these steps:


### PR DESCRIPTION
Especially after #297 ("editorial: Formally define a permission revocation
algorithm"), it makes more sense to reference this test from the definition
of the "screen-wake-lock" powerful feature, as the test has nothing to do
with the permission revocation algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/302.html" title="Last updated on Feb 10, 2021, 10:56 AM UTC (6c10bbc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/302/9b8a271...rakuco:6c10bbc.html" title="Last updated on Feb 10, 2021, 10:56 AM UTC (6c10bbc)">Diff</a>