### PR TITLE
editorial: Simplify the "obtain permission" algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,25 +217,16 @@
           these steps <a>in parallel</a>. This async algorithm returns either
           {{PermissionState/"granted"}} or {{PermissionState/"denied"}}.
         </p>
+        <aside class="note">
+          The following algorithm is defined in this specification because the
+          Permissions specification currently lacks integration with the
+          concept of user activation from [[HTML]]. See <a href=
+          "https://github.com/w3c/permissions/issues/194">this issue for more
+          information</a>.
+        </aside>
         <ol class="algorithm">
-          <li>Let |permissionDesc:PermissionDescriptor| be a newly created
-          {{PermissionDescriptor}}.
-          </li>
-          <li>Set |permissionDesc|'s {{PermissionDescriptor/name}} member to
-          "`screen-wake-lock`".
-          </li>
-          <li>Let |resultPromise:Promise| be the result of running <a>query a
-          permission</a> with |permissionDesc|.
-          </li>
-          <li>Await |resultPromise| to settle.
-          </li>
-          <li>If |resultPromise| rejects, return {{PermissionState/"denied"}}.
-          </li>
-          <li>Otherwise, let |status:PermissionStatus| be the result of
-          |resultPromise|.
-          </li>
-          <li>Let |state:PermissionState| be the value of
-          |status|.{{PermissionStatus/state}}.
+          <li>Let |state:PermissionState| be <a>permission state</a> of the
+          `"screen-wake-lock"` {{PermissionName}}.
           </li>
           <li>If |state| is not {{PermissionState/"prompt"}}, return |state|.
           </li>
@@ -243,7 +234,7 @@
           activation=], return {{PermissionState/"denied"}}.
           </li>
           <li>Otherwise, return the result of <a>requesting permission to
-          use</a> with |permissionDesc|.
+          use</a> the `"screen-wake-lock"` {{PermissionName}}.
           </li>
         </ol>
       </section>


### PR DESCRIPTION
Conceptually, the steps remain the same:
1. Return "granted" or "denied" if the permission state is set to either
   value.
2. Otherwise, return "denied" if there is no user activation.
3. Call the "request permission to use" algorithm from the Permissions spec
   in case there is user activation.

The difference is that we now do it in 4 steps rather than 10 by 1) using
the shorthands provided by the Permissions spec that allow us to use a
PermissionName rather than having to create a PermissionDescriptor in the
algorithms and 2) checking the "permission state" directly rather than
invoking Permissions.query() and manipulating a promise.

Ideally, we would remove this algorithm altogether in favor of the "request
permission to use" algorithm from the Permissions spec, but we need to keep
it in order to check for user activation in case we are in a "prompt"
state (see the discussion in #298).

By not manipulating promises anymore, this incidentally fixes #187.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/303.html" title="Last updated on Feb 10, 2021, 12:00 PM UTC (0e53a1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/303/01c2064...rakuco:0e53a1c.html" title="Last updated on Feb 10, 2021, 12:00 PM UTC (0e53a1c)">Diff</a>