### PR TITLE
editorial: Use Web IDL's "this" definition instead of "this object".

### DIFF
--- a/index.html
+++ b/index.html
@@ -500,7 +500,7 @@
           following steps:
         </p>
         <ol class="algorithm">
-          <li>If this object's {{[[Released]]}} internal slot is `true`, return
+          <li>If <a>this</a>' {{[[Released]]}} internal slot is `true`, return
           <a>a promise resolved with</a> `undefined`.
           </li>
           <li>Otherwise, let |promise:Promise| be <a>a new promise</a>.
@@ -508,8 +508,8 @@
           <li>Run the following steps <a>in parallel</a>:
             <ol>
               <li>Run <a>release a wake lock</a> with |lock:WakeLockSentinel|
-              set to this object and |type:WakeLockType| set to the value of
-              this object's {{WakeLockSentinel/type}} attribute.
+              set to <a>this</a> and |type:WakeLockType| set to the value of
+              <a>this</a>' {{WakeLockSentinel/type}} attribute.
               </li>
               <li>Resolve |promise|.
               </li>


### PR DESCRIPTION
This simplifies some of the language we use while also relying on a
well-defined concept from Web IDL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/304.html" title="Last updated on Feb 12, 2021, 11:52 AM UTC (de54e09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/304/8d76525...rakuco:de54e09.html" title="Last updated on Feb 12, 2021, 11:52 AM UTC (de54e09)">Diff</a>