### PR TITLE
Cite extra specifications in xref, not the data-cite attribute.

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,11 +48,17 @@
             href: 'https://github.com/Honry'
           }]
         }],
-        xref: "web-platform"
+        xref: {
+          profile: "web-platform",
+          specs: [
+            "permissions",
+            "permissions-policy",
+          ]
+        }
       };
     </script>
   </head>
-  <body data-cite="PERMISSIONS-POLICY PERMISSIONS">
+  <body>
     <section id='abstract'>
       <p>
         This document specifies an API that allows web applications to request


### PR DESCRIPTION
Follow ReSpec's recommendation and reference extra specs via the `xref`
configuration option instead of using the `data-cite` attribute in
<body> (which is not even officially allowed according to ReSpec's
documentation).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/305.html" title="Last updated on Feb 15, 2021, 10:31 AM UTC (982b183)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/305/c9d86b0...rakuco:982b183.html" title="Last updated on Feb 15, 2021, 10:31 AM UTC (982b183)">Diff</a>