### PR TITLE
editorial: Improve references to terms from the Page Visibility spec.

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
         xref: {
           profile: "web-platform",
           specs: [
+            "page-visibility",
             "permissions",
             "permissions-policy",
           ]
@@ -361,16 +362,18 @@
           |document| is not [=Document/fully active=], return [=a promise
           rejected with=] with a {{"NotAllowedError"}} {{DOMException}}.
           </li>
-          <li data-tests="wakelock-document-hidden-manual.https.html">If
-          |document| is <a>hidden</a>, return [=a promise rejected with=]
-          {{"NotAllowedError"}} {{DOMException}}.
+          <li data-tests="wakelock-document-hidden-manual.https.html">If the
+          steps to <a>determine the visibility state</a> return `hidden`,
+          return [=a promise rejected with=] {{"NotAllowedError"}}
+          {{DOMException}}.
           </li>
           <li>Let |promise:Promise| be [=a new promise=].
           </li>
           <li>Return |promise| and run the following steps <a>in parallel</a>:
             <ol>
               <li>
-                <a>Abort when</a> |document| is <a>hidden</a>.
+                <a>Abort when</a> the steps to <a>determine the visibility
+                state</a> return `hidden`.
               </li>
               <li>Let |state:PermissionState| be the result of awaiting
               <a>obtain permission</a> steps with "`screen-wake-lock`":
@@ -667,18 +670,18 @@
       <section>
         <h3>
           <dfn>Handling document loss of visibility</dfn>
-        </h3>
+        </h3><!-- Note: https://github.com/w3c/page-visibility/pull/47 formally
+             defines external hooks we can use here, but they are not part of
+             the latest TR, so we cannot reference them yet. -->
         <p data-tests="wakelock-document-hidden-manual.https.html">
-          When the user agent determines that the <a>visibility state</a> of
-          the [=environment settings object / responsible document=] of the
-          <a>current settings object</a> changes, it must run these steps:
+          When the user agent determines that the [=Document/visibility state=]
+          of the <a>Document</a> of the <a>top-level browsing context</a> has
+          become `hidden`, the user agent MUST run the following steps after
+          the <a>now hidden algorithm</a>:
         </p>
         <ol class="algorithm">
           <li>Let |document:Document| be the [=environment settings object /
           responsible document=] of the <a>current settings object</a>.
-          </li>
-          <li>If |document|'s <a>visibility state</a> is `"visible"`, abort
-          these steps.
           </li>
           <li>Let |screenRecord| be the <a>platform wake lock</a>'s <a>state
           record</a> associated with |document| and <a>wake lock type</a>
@@ -694,7 +697,8 @@
           </li>
         </ol>
         <aside class="note">
-          The <a>visibility state</a> is only exposed on the {{Window}} object.
+          The [=Document/visibility state=] is only exposed on the {{Window}}
+          object.
         </aside>
       </section>
       <section>
@@ -837,14 +841,16 @@
       </pre>
     </section>
     <section>
+      <!-- Note: https://github.com/w3c/page-visibility/pull/47 formally
+           defines external hooks we can use here, but they are not part of
+           the latest TR, so we cannot reference them yet. Once we can, this
+           whole section can be removed. -->
       <h2>
         Dependencies
       </h2>
       <p>
-        Document's <code><dfn data-cite=
-        "PAGE-VISIBILITY#dom-document-hidden">hidden</dfn></code> attribute,
-        and <dfn data-cite="PAGE-VISIBILITY#dfn-visibility-states">visibility
-        state</dfn> are defined in [[PAGE-VISIBILITY]].
+        The following is defined in [[PAGE-VISIBILITY]]: <dfn data-cite=
+        "PAGE-VISIBILITY#dfn-now-hidden-algorithm">now hidden algorithm</dfn>.
       </p>
     </section>
     <section id="conformance">


### PR DESCRIPTION
* @annevk says in #299 that, as a general rule, invoking IDL members from
  algorithms, like we were doing with `document.hidden`, is not recommended.
  Instead, invoke the "determine the visibility state" steps defined in the
  Page Visibility spec directly.

* Clean up the "Dependencies" section; for now we only need one term that is
  not exported by the latest Page Visibility TR (this is fixed in the ED):
  the "now hidden algorithm". The steps described in the "Handling document
  loss of visibility" steps now explicitly run after that algorithm, which
  runs when the top-level browsing context's Document becomes hidden.

More generally, these changes should also make it more clear that the
visibility state checks only apply to the top-level browsing
context (according to the Page Visibility spec itself). Although we were
previously checking if a given `Document` was `hidden` even if it did not
belong to a top-level browsing context, that was simply invalid.

The following tasks have been completed:

 * [x] Modified Web platform tests (not applicable)

Implementation commitment:

 * [x] Chromium (no change required, apparently)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/306.html" title="Last updated on Feb 15, 2021, 1:35 PM UTC (9bd2235)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/306/895be5a...rakuco:9bd2235.html" title="Last updated on Feb 15, 2021, 1:35 PM UTC (9bd2235)">Diff</a>