### PR TITLE
editorial: Adjust nesting levels in the WakeLock.request() algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,20 +339,16 @@
         <ol class="algorithm">
           <li>Let |document:Document| be the [=environment settings object /
           responsible document=] of the <a>current settings object</a>.
-            <ol>
-              <li data-tests=
-              "wakelock-disabled-by-feature-policy.https.sub.html">If
-              |document| is not [=allowed to use=] the [=policy-controlled
-              feature=] named "`screen-wake-lock`", return [=a promise rejected
-              with=] a {{"NotAllowedError"}} {{DOMException}}.
-              </li>
-              <li data-tests=
-              "wakelock-screen-type-on-worker.https.worker.html">If the <a>user
-              agent</a> <a>denies the wake lock</a> of this |type| for
-              |document|, return [=a promise rejected with=]
-              {{"NotAllowedError"}} {{DOMException}}.
-              </li>
-            </ol>
+          </li>
+          <li data-tests="wakelock-disabled-by-feature-policy.https.sub.html">
+          If |document| is not [=allowed to use=] the [=policy-controlled
+          feature=] named "`screen-wake-lock`", return [=a promise rejected
+          with=] a {{"NotAllowedError"}} {{DOMException}}.
+          </li>
+          <li data-tests="wakelock-screen-type-on-worker.https.worker.html">If
+          the <a>user agent</a> <a>denies the wake lock</a> of this |type| for
+          |document|, return [=a promise rejected with=] a
+          {{"NotAllowedError"}} {{DOMException}}.
           </li>
           <li>If the |document|'s [=Document/browsing context=] is `null`,
           return [=a promise rejected with=] {{"NotAllowedError"}}
@@ -376,12 +372,15 @@
                 state</a> return `hidden`.
               </li>
               <li>Let |state:PermissionState| be the result of awaiting
-              <a>obtain permission</a> steps with "`screen-wake-lock`":
+              <a>obtain permission</a> steps with "`screen-wake-lock`".
+              </li>
+              <li data-tests="wakelock-request-denied.https.html">If |state| is
+              {{PermissionState/"denied"}}, then:
                 <ol>
-                  <li data-tests="wakelock-request-denied.https.html">If
-                  |state| is {{PermissionState/"denied"}}, then reject
-                  |promise| with a {{"NotAllowedError"}} {{DOMException}}, and
-                  abort these steps.
+                  <li>Reject |promise| with a {{"NotAllowedError"}}
+                  {{DOMException}}.
+                  </li>
+                  <li>Abort these steps.
                   </li>
                 </ol>
               </li>


### PR DESCRIPTION
Incorporate suggestions made by @domenic in #299:
* Steps 1.1 and 1.2 which checked `document` should not be substeps of step
  1, but siblings just like other subsequent steps that also check
  `document`.
* Checking the value of `state` should be done at the same nesting level of
  the step that sets `state`, not as a nested substep.

These changes should have no user-visible effects.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/308.html" title="Last updated on Feb 27, 2021, 11:07 AM UTC (5d4f574)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/308/54f520c...rakuco:5d4f574.html" title="Last updated on Feb 27, 2021, 11:07 AM UTC (5d4f574)">Diff</a>