### PR TITLE
editorial: Say "this's" instead of "this'".

### DIFF
--- a/index.html
+++ b/index.html
@@ -509,7 +509,7 @@
           following steps:
         </p>
         <ol class="algorithm">
-          <li>If <a>this</a>' {{[[Released]]}} internal slot is `true`, return
+          <li>If <a>this</a>'s {{[[Released]]}} internal slot is `true`, return
           <a>a promise resolved with</a> `undefined`.
           </li>
           <li>Otherwise, let |promise:Promise| be <a>a new promise</a>.
@@ -518,7 +518,7 @@
             <ol>
               <li>Run <a>release a wake lock</a> with |lock:WakeLockSentinel|
               set to <a>this</a> and |type:WakeLockType| set to the value of
-              <a>this</a>' {{WakeLockSentinel/type}} attribute.
+              <a>this</a>'s {{WakeLockSentinel/type}} attribute.
               </li>
               <li>Resolve |promise|.
               </li>


### PR DESCRIPTION
This is the preferred form as found e.g. in the Web IDL and Fetch specs.
Originally spotted by @domenic while reviewing #299.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/309.html" title="Last updated on Feb 27, 2021, 11:08 AM UTC (b8ad60d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/309/54f520c...rakuco:b8ad60d.html" title="Last updated on Feb 27, 2021, 11:08 AM UTC (b8ad60d)">Diff</a>