### PR TITLE
Revert "workflows/tidy: Run on ubuntu-20.04. (#317)"

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -8,10 +8,10 @@ on:
 jobs:
   tidy:
     name: Tidy up
-    runs-on: ubuntu-20.04
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get install tidy
+      - run: brew install tidy-html5
       - run: tidy -config .tidyrc -o index.html index.html
       - uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
This reverts commit b6b47420748ee0975b6be4a919a28aaa4df1ae4e. The tidy 5.6.0
package shipped in Debian (up to bullseye at the time of writing) as well as
Ubuntu (up to 21.04 at least) is built with a patch that causes the
configurations settings we pass via `-config .tidyrc` to be ignored when
running (0011-Revert-Remove-unnecessary-AdjustConfig-logic.patch).

The easiest fix is to just revert the commit and continue running tidy on
macos-latest for the time being.
