### PR TITLE
editorial: Reference the "external now hidden" algorithm from Page Visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -680,14 +680,12 @@
       <section>
         <h3>
           <dfn>Handling document loss of visibility</dfn>
-        </h3><!-- Note: https://github.com/w3c/page-visibility/pull/47 formally
-             defines external hooks we can use here, but they are not part of
-             the latest TR, so we cannot reference them yet. -->
+        </h3>
         <p data-tests="wakelock-document-hidden-manual.https.html">
-          When the user agent determines that the [=Document/visibility state=]
-          of a {{Document}} |document:Document| of a <a>top-level browsing
-          context</a> has become `hidden`, the user agent MUST run the
-          following steps after the <a>now hidden algorithm</a>:
+          This specification defines the following <a>external now hidden
+          algorithm</a>, which is run when the user agent determines that the
+          [=Document/visibility state=] of a {{Document}} |document:Document|
+          of a <a>top-level browsing context</a> has become `hidden`:
         </p>
         <ol class="algorithm">
           <li>[=list/For each=] |lock:WakeLockSentinel| in
@@ -819,19 +817,6 @@
         lock1.release();
         lock2.release();
       </pre>
-    </section>
-    <section>
-      <!-- Note: https://github.com/w3c/page-visibility/pull/47 formally
-           defines external hooks we can use here, but they are not part of
-           the latest TR, so we cannot reference them yet. Once we can, this
-           whole section can be removed. -->
-      <h2>
-        Dependencies
-      </h2>
-      <p>
-        The following is defined in [[PAGE-VISIBILITY]]: <dfn data-cite=
-        "PAGE-VISIBILITY#dfn-now-hidden-algorithm">now hidden algorithm</dfn>.
-      </p>
     </section>
     <section id="conformance">
       <p>


### PR DESCRIPTION
A new Page Visibility TR has been published, and after a few follow-up
commits to the spec it is now possible to reference its "external now
hidden" algorithm, which is invoked when a page is hidden.

This change should have no user-visibile effects, as our current algorithm
was already supposed to run after the "visibilitychange" event is fired and
the page becomes hidden.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/320.html" title="Last updated on Jun 23, 2021, 3:28 PM UTC (7735b16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/320/2c32fe4...rakuco:7735b16.html" title="Last updated on Jun 23, 2021, 3:28 PM UTC (7735b16)">Diff</a>