### PR TITLE
Handle garbage collection

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,6 +546,23 @@
           {{WakeLockSentinel/onrelease}} event handler.
         </aside>
       </section>
+      <section>
+        <h3>
+          Garbage collection
+        </h3>
+        <p>
+          While a {{WakeLockSentinel}} object has one or more event listeners
+          registered for "release", there MUST be a strong reference from the
+          {{Window}} object that the {{WakeLockSentinel}} object's constructor
+          was invoked from to the {{WakeLockSentinel}} object itself.
+        </p>
+        <p>
+          While there is a task queued by an {{WakeLockSentinel}} object on the
+          <a>screen wake lock task source</a>, there MUST be a strong reference
+          from the {{Window}} object that the {{WakeLockSentinel}} object's
+          constructor was invoked from to that {{WakeLockSentinel}} object.
+        </p>
+      </section>
     </section>
     <section data-dfn-for="WakeLockType">
       <h2>

--- a/index.html
+++ b/index.html
@@ -552,7 +552,8 @@
         </h3>
         <p>
           While a {{WakeLockSentinel}} object has one or more event listeners
-          registered for "release", there MUST be a strong reference from the
+          registered for "release", and the {{WakeLockSentinel}} object hasn't
+          already been released, there MUST be a strong reference from the
           {{Window}} object that the {{WakeLockSentinel}} object's constructor
           was invoked from to the {{WakeLockSentinel}} object itself.
         </p>


### PR DESCRIPTION
The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [x] Chromium 
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
 * WebKit - Not participating in this working group. 

Handles this case:

```JS
async function run() {
  const sentinel = await navigator.wakeLock.request("screen");
  sentinel.addEvenListener("release", function() {
       // do stuff
       console.log("Sentinel released!");
  }, { once: true });
  return; 
  // `sentinel` shouldn't get CG here, because we have an event registered
  // "once" removes the listener, allowing the object to be GC'ed.
}

run(); 
``` 

I don't know if we have the means to test the above via WPT... can folks think of a way of doing it without a manual test? 

Presumedly, Chrome already implements the right thing here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/pull/322.html" title="Last updated on Aug 26, 2021, 1:40 AM UTC (195fa92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/322/48028ac...195fa92.html" title="Last updated on Aug 26, 2021, 1:40 AM UTC (195fa92)">Diff</a>