### PR TITLE
editorial: Use Web IDL's definition conventions for methods and getters.

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,9 +310,7 @@
           The <dfn>request()</dfn> method
         </h3>
         <p data-tests="wakelock-type.https.any.html">
-          The {{WakeLock/request()}} method, when invoked, MUST run the
-          following steps. The method takes one argument, the {{WakeLockType}}
-          |type:WakeLockType|:
+          The <code>request(|type:WakeLockType|)</code> method steps are:
         </p>
         <ol class="algorithm">
           <li>Let |document:Document| be [=this=]'s [=relevant settings
@@ -483,8 +481,8 @@
           The <dfn>released</dfn> attribute
         </h3>
         <p data-tests="wakelock-released.https.html">
-          The {{WakeLockSentinel/released}} attribute's getter returns the
-          value of the {{WakeLockSentinel/[[Released]]}} internal slot.
+          The {{WakeLockSentinel/released}} getter steps are to return
+          [=this=].{{WakeLockSentinel/[[Released]]}}.
         </p>
         <aside class="note">
           Once a {{WakeLockSentinel}} is released,
@@ -497,8 +495,8 @@
           The <dfn>type</dfn> attribute
         </h3>
         <p>
-          The {{WakeLockSentinel/type}} attribute corresponds to the
-          {{WakeLockSentinel}}'s <a>wake lock type</a>.
+          The {{WakeLockSentinel/type}} getter steps are to return [=this=]'s
+          <a>wake lock type</a>.
         </p>
       </section>
       <section>
@@ -506,8 +504,7 @@
           The <dfn>release()</dfn> method
         </h3>
         <p data-tests="wakelock-onrelease.https.html">
-          The {{WakeLockSentinel/release()}} method, when invoked, MUST run the
-          following steps:
+          The {{WakeLockSentinel/release()}} method steps are:
         </p>
         <ol class="algorithm">
           <li>If <a>this</a>'s {{WakeLockSentinel/[[Released]]}} is `false`,


### PR DESCRIPTION
Aligns with whatwg/webidl#882:
- Describe getters as "The attr getter steps are [...]".
- Describe methods as "The myMethod(arg) method steps are [...]".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/330.html" title="Last updated on Nov 5, 2021, 12:47 PM UTC (10f1054)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/330/4eddbe4...rakuco:10f1054.html" title="Last updated on Nov 5, 2021, 12:47 PM UTC (10f1054)">Diff</a>