### PR TITLE
editorial: Adapt to Page Visibility spec integration into HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,10 +336,9 @@
           |document| is not [=Document/fully active=], return [=a promise
           rejected with=] with a {{"NotAllowedError"}} {{DOMException}}.
           </li>
-          <li data-tests="wakelock-document-hidden-manual.https.html">If the
-          steps to <a>determine the visibility state</a> return `hidden`,
-          return [=a promise rejected with=] {{"NotAllowedError"}}
-          {{DOMException}}.
+          <li data-tests="wakelock-document-hidden-manual.https.html">If
+          |document|'s [=Document/visibility state=] is "`hidden`", return [=a
+          promise rejected with=] {{"NotAllowedError"}} {{DOMException}}.
           </li>
           <li>Let |promise:Promise| be [=a new promise=].
           </li>
@@ -366,8 +365,8 @@
                 source</a> given |document|'s <a>relevant global object</a> to
                 run these steps:
                 <ol>
-                  <li>If the steps to <a>determine the visibility state</a>
-                  return `hidden`, then:
+                  <li>If |document|'s [=Document/visibility state=] is
+                  "`hidden`", then:
                     <ol>
                       <li>Reject |promise| with a {{"NotAllowedError"}}
                       {{DOMException}}.
@@ -677,12 +676,13 @@
           <dfn>Handling document loss of visibility</dfn>
         </h3>
         <p data-tests="wakelock-document-hidden-manual.https.html">
-          This specification defines the following <a>external now hidden
-          algorithm</a>, which is run when the user agent determines that the
-          [=Document/visibility state=] of a {{Document}} |document:Document|
-          of a <a>top-level browsing context</a> has become `hidden`:
+          This specification defines the following [=page visibility change
+          steps=] with [=Document/visibility state=] |state| and
+          |document:Document|:
         </p>
         <ol class="algorithm">
+          <li>If |state| is not "`hidden`", abort these steps.
+          </li>
           <li>[=list/For each=] |lock:WakeLockSentinel| in
           |document|.{{Document/[[ActiveLocks]]}}["`screen`"]:
             <ol>
@@ -692,10 +692,6 @@
             </ol>
           </li>
         </ol>
-        <aside class="note">
-          The [=Document/visibility state=] is only exposed on the {{Window}}
-          object.
-        </aside>
       </section>
       <section>
         <h3>


### PR DESCRIPTION
The Page Visibility spec has been merged into the HTML spec itself. This
merge got rid of some terms and changed a few others, so adjust things
accordingly here:

* Instead of calling the "determine the visibility state", access a
  Document's "visibility state" directly.
* The "external now hidden algorithm" no longer exists; now there are "page
  visibility change steps" called with a Document and a visibility state.
  (The HTML spec itself says specs should have the HTML spec call these
  steps so that the order of calls is defined in the spec, which we might
  need to do later).

Fixes #331


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/332.html" title="Last updated on Dec 5, 2021, 4:34 PM UTC (5203536)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/332/4eddbe4...rakuco:5203536.html" title="Last updated on Dec 5, 2021, 4:34 PM UTC (5203536)">Diff</a>