### PR TITLE
Remove "page-visibility" from xref spec list.

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,6 @@
         xref: {
           profile: "web-platform",
           specs: [
-            "page-visibility",
             "permissions",
             "permissions-policy",
           ]


### PR DESCRIPTION
Follow-up to #332. The Page Visibility spec was merged into the HTML spec
itself, so we do not need to explicitly reference it from `xref` anymore.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/333.html" title="Last updated on Dec 7, 2021, 11:46 AM UTC (366e2f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/333/dc2008b...rakuco:366e2f9.html" title="Last updated on Dec 7, 2021, 11:46 AM UTC (366e2f9)">Diff</a>