### PR TITLE
editorial: Fetch an associated document from a global, not settings object

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
           Wake Lock permission revocation algorithm</dfn>, run these steps:
         </p>
         <ol class="algorithm">
-          <li>Let |document:Document| be the [=current settings object=]'s
+          <li>Let |document:Document| be the [=current global object=]'s
           [=associated Document=].
           </li>
           <li>Let |lockList| be
@@ -312,7 +312,7 @@
           The <code>request(|type:WakeLockType|)</code> method steps are:
         </p>
         <ol class="algorithm">
-          <li>Let |document:Document| be [=this=]'s [=relevant settings
+          <li>Let |document:Document| be [=this=]'s [=relevant global
           object=]'s [=associated Document=].
           </li>
           <li data-tests="wakelock-disabled-by-feature-policy.https.sub.html">


### PR DESCRIPTION
A settings object does not have an associated document; a global object
does.

Grab the associated document from the right place after #311 ('Editorial:
remove uses of "responsible document"').

Fixes #346.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/347.html" title="Last updated on Sep 15, 2022, 9:34 PM UTC (d82d991)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/347/4cea6d3...rakuco:d82d991.html" title="Last updated on Sep 15, 2022, 9:34 PM UTC (d82d991)">Diff</a>