### PR TITLE
Remove note from the "Handling document loss of full activity" section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -662,11 +662,6 @@
             </ol>
           </li>
         </ol>
-        <aside class="note">
-          Only documents presented to the user, thus with an associated
-          [=Document/browsing context=] can be <a>active documents</a>, so the
-          above steps are only relevant for these.
-        </aside>
       </section>
       <section>
         <h3>


### PR DESCRIPTION
The reference to "active document" was broken after whatwg/html#6315 (it now belongs to a "navigable").

Rather than trying to make sense of the changes to the HTML spec, just remove the note since it was not adding a lot of information anyway.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/354.html" title="Last updated on Nov 21, 2022, 2:32 PM UTC (c17f914)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/354/c8722b1...rakuco:c17f914.html" title="Last updated on Nov 21, 2022, 2:32 PM UTC (c17f914)">Diff</a>