### PR TITLE
Reference the "release the wake lock" definition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -600,10 +600,10 @@
       </p>
       <p>
         Conversely, the <a>user agent</a> <dfn data-lt=
-        "release wake lock">releases the wake lock</dfn> by requesting the
-        underlying operating system to no longer apply the wake lock. The lock
-        is considered released only when the request to the operating system
-        succeeds.
+        "release wake lock|release the wake lock">releases the wake lock</dfn>
+        by requesting the underlying operating system to no longer apply the
+        wake lock. The lock is considered released only when the request to the
+        operating system succeeds.
       </p>
       <p>
         The wake lock is <dfn data-lt=
@@ -720,9 +720,9 @@
           <li>If |document|.{{Document/[[ActiveLocks]]}}[|type|] [=list/is
           empty=], then run the following steps <a>in parallel</a>:
             <ol>
-              <li>Ask the underlying operating system to release the wake lock
-              of type |type| and let |success:boolean| be `true` if the
-              operation succeeded, or else `false`.
+              <li>Ask the underlying operating system to <a>release the wake
+              lock</a> of type |type| and let |success:boolean| be `true` if
+              the operation succeeded, or else `false`.
               </li>
               <li>If |success| is `true` and |type| is `"screen"` run the
               following:


### PR DESCRIPTION
This refers to asking the OS to drop its platform lock. We had a definition that was not being used anywhere, and ReSpec was showing a warning about it.

Reference it from the most obvious location: the "release a wake lock" algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/355.html" title="Last updated on Nov 22, 2022, 1:28 PM UTC (6160f4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/355/3c4c86b...rakuco:6160f4b.html" title="Last updated on Nov 22, 2022, 1:28 PM UTC (6160f4b)">Diff</a>