### PR TITLE
Permissions Policy: update default allowlist notation + small fixes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,14 +132,14 @@
         Policy control
       </h3>
       <p data-tests=
-      "wakelock-supported-by-feature-policy.html, wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html, wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html, wakelock-enabled-by-feature-policy-attribute.https.sub.html, wakelock-enabled-by-feature-policy.https.sub.html">
+      "wakelock-supported-by-permissions-policy.html, wakelock-enabled-on-self-origin-by-permissions-policy.https.sub.html, wakelock-enabled-by-permissions-policy-attribute-redirect-on-load.https.sub.html, wakelock-enabled-by-permissions-policy-attribute.https.sub.html, wakelock-enabled-by-permissions-policy.https.sub.html">
         The Screen Wake Lock API defines a [=policy-controlled feature=]
         identified by the string `"screen-wake-lock"`. Its [=default
-        allowlist=] is `["self"]`.
+        allowlist=] is `'self'`.
       </p>
       <aside class="note">
         <p>
-          The <a>default allowlist</a> of `["self"]` allows wake lock usage in
+          The <a>default allowlist</a> of `'self'` allows wake lock usage in
           same-origin nested frames but prevents third-party content from using
           wake locks.
         </p>
@@ -155,8 +155,8 @@
           Alternatively, the Screen Wake Lock API can be disabled completely by
           specifying the permissions policy in a HTTP response header:
         </p>
-        <pre class="example http" title="Feature Policy over HTTP">
-          Permissions-Policy: {"screen-wake-lock": []}
+        <pre class="example http" title="Permissions Policy header">
+          Permissions-Policy: screen-wake-lock=()
         </pre>
         <p>
           See [[[PERMISSIONS-POLICY]]] for more details.
@@ -316,8 +316,9 @@
           <li>Let |document:Document| be [=this=]'s [=relevant global
           object=]'s [=associated Document=].
           </li>
-          <li data-tests="wakelock-disabled-by-feature-policy.https.sub.html">
-          If |document| is not [=allowed to use=] the [=policy-controlled
+          <li data-tests=
+          "wakelock-disabled-by-permissions-policy.https.sub.html">If
+          |document| is not [=allowed to use=] the [=policy-controlled
           feature=] named "`screen-wake-lock`", return [=a promise rejected
           with=] a {{"NotAllowedError"}} {{DOMException}}.
           </li>


### PR DESCRIPTION
* w3c/webappsec-permissions-policy#123 clarified the notation and types used by allowlists and default allowlists. Default allowlists are not allowlists themselves, so we need to use `"self"` rather than `["self"]`.

While here, land a few minor adjustments:
* Fix references to Permissions Policy tests in WPT that were renamed in web-platform-tests/wpt#36159.
* Use the right notation in the Permissions-Policy HTTP header example. The syntax we were using had not been valid since 2017's w3c/webappsec-permissions-policy#83.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/356.html" title="Last updated on Nov 23, 2022, 11:22 AM UTC (b33d92a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/356/0b18eba...rakuco:b33d92a.html" title="Last updated on Nov 23, 2022, 11:22 AM UTC (b33d92a)">Diff</a>