### PR TITLE
editorial: Fix references to "default allowlist".

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,14 +134,14 @@
       <p data-tests=
       "wakelock-supported-by-permissions-policy.html, wakelock-enabled-on-self-origin-by-permissions-policy.https.sub.html, wakelock-enabled-by-permissions-policy-attribute-redirect-on-load.https.sub.html, wakelock-enabled-by-permissions-policy-attribute.https.sub.html, wakelock-enabled-by-permissions-policy.https.sub.html">
         The Screen Wake Lock API defines a [=policy-controlled feature=]
-        identified by the string `"screen-wake-lock"`. Its [=default
-        allowlist=] is `'self'`.
+        identified by the string `"screen-wake-lock"`. Its [=policy-controlled
+        feature/default allowlist=] is `'self'`.
       </p>
       <aside class="note">
         <p>
-          The <a>default allowlist</a> of `'self'` allows wake lock usage in
-          same-origin nested frames but prevents third-party content from using
-          wake locks.
+          The [=policy-controlled feature/default allowlist=] of `'self'`
+          allows wake lock usage in same-origin nested frames but prevents
+          third-party content from using wake locks.
         </p>
         <p>
           Third-party usage can be selectively enabled by adding


### PR DESCRIPTION
"Default allowlist" is a scoped concept associated with "policy-controlled
feature". Make the association explicit to get ReSpec to link to the right
definition instead of showing an error.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/wake-lock/pull/361.html" title="Last updated on Apr 6, 2023, 8:45 AM UTC (bb3222e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/361/d21d449...rakuco:bb3222e.html" title="Last updated on Apr 6, 2023, 8:45 AM UTC (bb3222e)">Diff</a>