### PR TITLE
Remove browsing context check from WakeLock.request()

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,10 +327,6 @@
           |document|, return [=a promise rejected with=] a
           {{"NotAllowedError"}} {{DOMException}}.
           </li>
-          <li>If the |document|'s [=Document/browsing context=] is `null`,
-          return [=a promise rejected with=] {{"NotAllowedError"}}
-          {{DOMException}}.
-          </li>
           <li data-tests="wakelock-active-document.https.window.html">If
           |document| is not [=Document/fully active=], return [=a promise
           rejected with=] with a {{"NotAllowedError"}} {{DOMException}}.


### PR DESCRIPTION
Since whatwg/html#6315, the HTML spec suggests other specifications use
"navigable" and associated concepts (along with Document) rather than
"browsing context" in most cases.

In this specific case, however, we can simply remove the step that checks if
`document`'s browsing context is null -- there is no case in which a
document is fully active _and_ has a null browsing context, as confirmed by
whatwg/html#9509.

Fixes #362.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/pull/363.html" title="Last updated on Jul 14, 2023, 8:26 AM UTC (79d38db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/363/40fd166...79d38db.html" title="Last updated on Jul 14, 2023, 8:26 AM UTC (79d38db)">Diff</a>