### PR TITLE
editorial: Add an index to the appendices

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,7 +816,6 @@
         <dfn>user agent</dfn> that implements the interfaces that it contains.
       </p>
     </section>
-    <section id="idl-index" class="appendix"></section>
     <section class="appendix informative" id="acknowledgments">
       <h2>
         Acknowledgments
@@ -877,5 +876,7 @@
         </ul>
       </section>
     </section>
+    <section id="index" class="appendix"></section>
+    <section id="idl-index" class="appendix"></section>
   </body>
 </html>


### PR DESCRIPTION
This makes it easier to see all the terms that this specification defines.

While here, move the IDL Index to the end of the document to keep both indices together and after all the human-generated content.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/pull/364.html" title="Last updated on Jul 19, 2023, 12:28 PM UTC (f4b2e24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/364/37cbcc2...f4b2e24.html" title="Last updated on Jul 19, 2023, 12:28 PM UTC (f4b2e24)">Diff</a>