### PR TITLE
editorial: Use more precise terms to define WakeLockSentinel.onrelease

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,9 +517,10 @@
           The <dfn>onrelease</dfn> attribute
         </h3>
         <p>
-          The {{WakeLockSentinel/onrelease}} attribute is an <a>event
-          handler</a> whose corresponding <a>event handler event type</a> is
-          <code>release</code>.
+          The {{WakeLockSentinel/onrelease}} attribute is an <a>event handler
+          IDL attribute</a> for the "<code>onrelease</code>" <a>event
+          handler</a>, whose <a>event handler event type</a> is
+          "<dfn><code>release</code></dfn>".
         </p>
         <p>
           It is used to notify scripts that a given {{WakeLockSentinel}}
@@ -545,10 +546,11 @@
         </h3>
         <p>
           While a {{WakeLockSentinel}} object has one or more event listeners
-          registered for "release", and the {{WakeLockSentinel}} object hasn't
-          already been released, there MUST be a strong reference from the
-          {{Window}} object that the {{WakeLockSentinel}} object's constructor
-          was invoked from to the {{WakeLockSentinel}} object itself.
+          registered for "<a><code>release</code></a>", and the
+          {{WakeLockSentinel}} object hasn't already been released, there MUST
+          be a strong reference from the {{Window}} object that the
+          {{WakeLockSentinel}} object's constructor was invoked from to the
+          {{WakeLockSentinel}} object itself.
         </p>
         <p>
           While there is a task queued by an {{WakeLockSentinel}} object on the
@@ -738,7 +740,7 @@
           <li>Set |lock|'s {{WakeLockSentinel/[[Released]]}} to `true`.
           </li>
           <li>
-            <a>Fire an event</a> named "`release`" at |lock|.
+            <a>Fire an event</a> named "<a><code>release</code></a>" at |lock|.
           </li>
         </ol>
       </section>


### PR DESCRIPTION
- Say onrelease is an event handler IDL attribute instead of just an event
  handler.
- Use a name to refer to the event handler itself (it is called "onrelease").
- Make the "release" event handler type a <dfn> and refer to it in the rest of
  the spec.

This commit does not introduce any user-visible changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/pull/365.html" title="Last updated on Oct 31, 2023, 5:24 PM UTC (beb2615)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/365/7f33f5a...beb2615.html" title="Last updated on Oct 31, 2023, 5:24 PM UTC (beb2615)">Diff</a>