### PR TITLE
Remove redundant check

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,16 +360,6 @@
                 source</a> given |document|'s <a>relevant global object</a> to
                 run these steps:
                 <ol>
-                  <li>If |document|'s [=Document/visibility state=] is
-                  "`hidden`", then:
-                    <ol>
-                      <li>Reject |promise| with a {{"NotAllowedError"}}
-                      {{DOMException}}.
-                      </li>
-                      <li>Abort these steps.
-                      </li>
-                    </ol>
-                  </li>
                   <li>If |document|.{{Document/[[ActiveLocks]]}}["`screen`"]
                   [=list/is empty=], then invoke the following steps <a>in
                   parallel</a>:


### PR DESCRIPTION
Closes #???

This check is not needed (or it's too eager because it's done on the wrong thread)... we do the check visibility check synchronously first. 

There are rules already in place as to what to do if the visibility is lost after the lock is acquired. 

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=) 
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/pull/368.html" title="Last updated on Dec 18, 2023, 2:42 AM UTC (2a3a5e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/368/b25d76b...2a3a5e3.html" title="Last updated on Dec 18, 2023, 2:42 AM UTC (2a3a5e3)">Diff</a>