### PR TITLE
Fix the build

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
           w3cid: "75989"
         },],
         github: "https://github.com/w3c/screen-wake-lock/",
-        group: [ "das", "webapps" ],
+        group: "das",
         testSuiteURI: "https://wpt.live/screen-wake-lock/",
         implementationReportURI: "https://www.w3.org/wiki/DAS/Implementations",
         otherLinks: [{


### PR DESCRIPTION
This reverts w3c/screen-wake-lock#371 to fix the build in the interim.

Context: https://lists.w3.org/Archives/Public/public-device-apis/2024Mar/0022.html


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/pull/372.html" title="Last updated on Mar 26, 2024, 3:29 PM UTC (464a5f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-wake-lock/372/54b800f...464a5f4.html" title="Last updated on Mar 26, 2024, 3:29 PM UTC (464a5f4)">Diff</a>